### PR TITLE
feat(cli): add routes command + addon config directory support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,9 @@ training_args.bin
 # OpenClaw local artifacts
 .openclaw/
 
+# Test artifacts
+tests/_artifacts/
+
 # Runtime data should stay out of git (code/data separation)
 data/*
 !data/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,10 @@ ENV/
 env.bak/
 venv.bak/
 
+# Local runtime config (keep examples tracked, keep real values local)
+config/*.local.json
+config/*_local.json
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/README.md
+++ b/README.md
@@ -354,4 +354,4 @@ This project is licensed under the Apache License 2.0. See the LICENSE file for 
 
 CiteWeave is in an early stage of development and may have bugs or missing features. If you encounter any issues, please feel free to [open an issue](https://github.com/Tiresiasel/CiteWeave/issues) or submit a pull request. Your feedback and contributions are very welcome!
 
-If you find this project interesting or want to collaborate, you can contact me directly (machespresso@gmail.com).
+If you find this project interesting or want to collaborate, please open an issue or discussion in the repository.

--- a/README.zh.md
+++ b/README.zh.md
@@ -351,4 +351,4 @@ python -m src.core.cli progress /papers/ --clear
 
 CiteWeave 仍处于早期开发阶段，可能存在bug或功能不全。如遇到问题，欢迎[提交 issue](https://github.com/Tiresiasel/CiteWeave/issues)或PR，您的反馈和贡献非常宝贵！
 
-如果你觉得本项目有趣或希望合作，欢迎直接联系我 (machespresso@gmail.com)。
+如果你觉得本项目有趣或希望合作，欢迎直接在仓库中提交 issue 或 discussion。

--- a/config/neo4j_config.example.json
+++ b/config/neo4j_config.example.json
@@ -3,4 +3,4 @@
   "username": "neo4j",
   "password": "CHANGE_ME_LOCAL_ONLY",
   "database": "neo4j"
-} 
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "7687:7687"  # Bolt protocol
       - "7474:7474"  # HTTP web UI
     environment:
-      - NEO4J_AUTH=neo4j/12345678
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-CHANGE_ME_LOCAL_ONLY}
       - NEO4J_dbms_security_auth__enabled=true
     volumes:
       - neo4j_data:/data

--- a/scripts/repo_privacy_audit.py
+++ b/scripts/repo_privacy_audit.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
+import fnmatch
 import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
 
+Violation = Tuple[str, str]
 REPO = Path(__file__).resolve().parents[1]
-TRACKED = subprocess.check_output(['git', '-C', str(REPO), 'ls-files'], text=True).splitlines()
 
-PATTERNS = [
+CONTENT_PATTERNS = [
     (re.compile(r'/home/tiresias|\.openclaw/workspace'), 'absolute local workspace path'),
     (re.compile(r'machespresso@gmail\.com', re.I), 'personal email'),
     (re.compile(r'\.secrets/|token file /home/', re.I), 'local secret/token path'),
@@ -15,26 +17,69 @@ PATTERNS = [
     (re.compile(r'"password"\s*:\s*"12345678"'), 'hard-coded Neo4j password in config'),
 ]
 
-violations = []
-for rel in TRACKED:
-    if rel.startswith('.venv/') or rel == 'scripts/repo_privacy_audit.py':
-        continue
-    p = REPO / rel
-    if not p.is_file():
-        continue
-    try:
-        text = p.read_text(encoding='utf-8', errors='ignore')
-    except Exception:
-        continue
-    for rx, label in PATTERNS:
-        if rx.search(text):
-            violations.append((rel, label))
-            break
+PATH_GUARDS = [
+    ('*.local.json', 'tracked local override config'),
+    ('*_local.json', 'tracked local override config'),
+    ('.env', 'tracked local environment file'),
+    ('.env.*', 'tracked local environment file'),
+]
 
-if violations:
-    print('PRIVACY_AUDIT_FAIL')
-    for rel, label in violations:
-        print(f'{rel}\t{label}')
-    sys.exit(1)
+EXCLUDED_PATHS = {
+    'scripts/repo_privacy_audit.py',
+}
+EXCLUDED_PREFIXES = ('.venv/',)
 
-print('PRIVACY_AUDIT_OK')
+
+def tracked_files(repo: Path) -> List[str]:
+    return subprocess.check_output(['git', '-C', str(repo), 'ls-files'], text=True).splitlines()
+
+
+
+def should_skip(rel_path: str) -> bool:
+    return rel_path in EXCLUDED_PATHS or rel_path.startswith(EXCLUDED_PREFIXES)
+
+
+
+def scan_repo(repo: Path, tracked: Sequence[str] | None = None) -> List[Violation]:
+    tracked = tracked if tracked is not None else tracked_files(repo)
+    violations: List[Violation] = []
+
+    for rel in tracked:
+        if should_skip(rel):
+            continue
+
+        for pattern, label in PATH_GUARDS:
+            if fnmatch.fnmatch(rel, pattern):
+                violations.append((rel, label))
+                break
+        else:
+            path = repo / rel
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(encoding='utf-8', errors='ignore')
+            except Exception:
+                continue
+            for rx, label in CONTENT_PATTERNS:
+                if rx.search(text):
+                    violations.append((rel, label))
+                    break
+
+    return violations
+
+
+
+def emit_report(violations: Iterable[Violation]) -> int:
+    violations = list(violations)
+    if violations:
+        print('PRIVACY_AUDIT_FAIL')
+        for rel, label in violations:
+            print(f'{rel}\t{label}')
+        return 1
+
+    print('PRIVACY_AUDIT_OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(emit_report(scan_repo(REPO)))

--- a/scripts/repo_privacy_audit.py
+++ b/scripts/repo_privacy_audit.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TRACKED = subprocess.check_output(['git', '-C', str(REPO), 'ls-files'], text=True).splitlines()
+
+PATTERNS = [
+    (re.compile(r'/home/tiresias|\.openclaw/workspace'), 'absolute local workspace path'),
+    (re.compile(r'machespresso@gmail\.com', re.I), 'personal email'),
+    (re.compile(r'\.secrets/|token file /home/', re.I), 'local secret/token path'),
+    (re.compile(r'NEO4J_AUTH=neo4j/12345678'), 'hard-coded Neo4j password'),
+    (re.compile(r'"password"\s*:\s*"12345678"'), 'hard-coded Neo4j password in config'),
+]
+
+violations = []
+for rel in TRACKED:
+    if rel.startswith('.venv/') or rel == 'scripts/repo_privacy_audit.py':
+        continue
+    p = REPO / rel
+    if not p.is_file():
+        continue
+    try:
+        text = p.read_text(encoding='utf-8', errors='ignore')
+    except Exception:
+        continue
+    for rx, label in PATTERNS:
+        if rx.search(text):
+            violations.append((rel, label))
+            break
+
+if violations:
+    print('PRIVACY_AUDIT_FAIL')
+    for rel, label in violations:
+        print(f'{rel}\t{label}')
+    sys.exit(1)
+
+print('PRIVACY_AUDIT_OK')

--- a/scripts/repo_privacy_audit.py
+++ b/scripts/repo_privacy_audit.py
@@ -15,11 +15,20 @@ CONTENT_PATTERNS = [
     (re.compile(r'\.secrets/|token file /home/', re.I), 'local secret/token path'),
     (re.compile(r'NEO4J_AUTH=neo4j/12345678'), 'hard-coded Neo4j password'),
     (re.compile(r'"password"\s*:\s*"12345678"'), 'hard-coded Neo4j password in config'),
+    (re.compile(r'ghp_[A-Za-z0-9]{36}\b'), 'GitHub personal access token'),
+    (re.compile(r'github_pat_[A-Za-z0-9_]{20,}\b'), 'GitHub fine-grained personal access token'),
+    (re.compile(r'sk-(?:proj-)?[A-Za-z0-9_-]{24,}\b'), 'OpenAI API key-like secret'),
+    (re.compile(r'-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'), 'private key material'),
 ]
 
 PATH_GUARDS = [
     ('*.local.json', 'tracked local override config'),
     ('*_local.json', 'tracked local override config'),
+    ('*.local.yaml', 'tracked local override config'),
+    ('*.local.yml', 'tracked local override config'),
+    ('*.local.toml', 'tracked local override config'),
+    ('*.local.ini', 'tracked local override config'),
+    ('*.local.env', 'tracked local override config'),
     ('.env', 'tracked local environment file'),
     ('.env.*', 'tracked local environment file'),
 ]

--- a/scripts/setup_all_services.py
+++ b/scripts/setup_all_services.py
@@ -13,7 +13,9 @@ CONFIG_DIR = os.path.join(os.path.dirname(__file__), '..', 'config')
 
 # --- Utility functions ---
 def load_json(path):
-    with open(path, 'r', encoding='utf-8') as f:
+    local_path = path.replace('.json', '.local.json')
+    actual = local_path if os.path.exists(local_path) else path
+    with open(actual, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 def setup_neo4j(config):

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -168,7 +168,7 @@ print(result["response"])
 - Update route constants/helpers in `routing.py` first (single source of truth), then update smart router prompts/examples.
 - Use `active_route_configuration()` when an addon or diagnostic surface needs the effective alias / priority snapshot after safe environment overrides are applied.
 - `active_route_configuration()` also reports `ignored_alias_overrides` and `ignored_priority_overrides` so addon diagnostics can explain why a user-supplied override was rejected instead of silently failing.
-- `CITEWEAVE_ROUTE_ADDON_CONFIG` may point to one JSON file or a platform-path-separated stack of JSON files (loaded left-to-right, later files override earlier file entries). `active_route_configuration()` exposes both the raw env value and expanded file list for debugging layered addon configs.
+- `CITEWEAVE_ROUTE_ADDON_CONFIG` may point to one JSON file, a platform-path-separated stack of JSON files, or directories containing top-level `*.json` files (loaded left-to-right, later files override earlier file entries; directory files load in sorted order). `active_route_configuration()` exposes both the raw env value and expanded file list for debugging layered addon configs.
 - Addons may add new aliases (for example `citation_map` → `graph_analysis`), but they cannot remap canonical route names or built-in short aliases such as `graph`, `vector`, `pdf`, and `author`.
 - Normalized-key collisions are rejected for diagnostics instead of silently overwriting earlier entries (for example `semantic-search` and `semantic search` are treated as the same key).
 - Ensure your agent returns results in the expected format for response synthesis.

--- a/src/agents/multi_agent_research_system.py
+++ b/src/agents/multi_agent_research_system.py
@@ -1428,20 +1428,37 @@ class QueryPlanningAgent:
                 })
                 step_counter += 1
         else:
-            # Special handling for paper search when we have a paper_id from fuzzy matching
-            if intent.query_type == QueryType.PAPER_SEARCH and target_entity.get("paper_id"):
-                # We have a specific paper, search its content directly
-                paper_id = target_entity["paper_id"]
-                plan["query_sequence"].append({
-                    "step": step_counter,
-                    "database": "vector_db",
-                    "method": "search_all_collections",
-                    "params": {"query": f"paper_id:{paper_id} {intent.original_question}", "limit_per_collection": 10},
-                    "expected_result": "search_results",
-                    "required": True,
-                    "reasoning": f"Found specific paper {paper_id}, searching its content"
-                })
-                step_counter += 1
+            # Special handling for paper search when we have a specific paper id/title
+            if intent.query_type == QueryType.PAPER_SEARCH and target_entity and (target_entity.get("paper_id") or target_entity.get("id") or target_entity.get("title")):
+                paper_id = target_entity.get("paper_id") or target_entity.get("id")
+                if paper_id:
+                    # First, try structured content fetch for this paper
+                    plan["query_sequence"].append({
+                        "step": step_counter,
+                        "database": "vector_db",
+                        "method": "get_full_pdf_content",
+                        "params": {"paper_id": paper_id},
+                        "expected_result": "full_pdf_content",
+                        "required": False,
+                        "reasoning": f"Found specific paper {paper_id}, fetch full content directly"
+                    })
+                    step_counter += 1
+                else:
+                    # Fallback: title-based content query when only title could be matched
+                    target_title = target_entity.get("title") or target_entity.get("name") or intent.target_entity
+                    plan["query_sequence"].append({
+                        "step": step_counter,
+                        "database": "vector_db",
+                        "method": "query_pdf_by_title_and_content",
+                        "params": {
+                            "title_query": target_title,
+                            "content_query": intent.original_question
+                        },
+                        "expected_result": "search_results",
+                        "required": True,
+                        "reasoning": f"Found candidate title '{target_title}', searching paper content by title"
+                    })
+                    step_counter += 1
             else:
                 # Use mapping table for other cases
                 key = (intent.query_type, intent.entity_type)
@@ -2419,6 +2436,12 @@ Please create a comprehensive summary that highlights these specific numbers and
                 if result.get("found"):
                     count = 1
                     stats["collection_stats"]["papers"] += 1
+                    # Also count extracted structured sections if available
+                    section_count = len(result.get("section_summaries", [])) or result.get("sections_count", 0) or len(result.get("data", {}).get("sections", []))
+                    stats["collection_stats"]["sections"] += section_count
+                    stats["collection_stats"]["paragraphs"] += 0
+                    stats["collection_stats"]["sentences"] += result.get("data", {}).get("sentence_count", 0)
+                    stats["collection_stats"]["citations"] += 0
                     pdf_title = result.get("metadata", {}).get("title", "PDF Content")
                     pdf_authors = result.get("metadata", {}).get("authors", [])
                     author_str = ", ".join(pdf_authors[:2]) if pdf_authors else "Unknown"
@@ -3682,7 +3705,7 @@ Please respond with: CONTINUE or EXPAND
                         return state
                     
                     # Determine what type of analysis is needed based on the question
-                    content_keywords = ["summarize", "findings", "content", "arguments", "main points"]
+                    content_keywords = ["summarize", "summary", "findings", "content", "argument", "arguments", "main argument", "main points", "claim", "claims", "conclusion", "hypothesis"]
                     is_content_query = any(keyword in question.lower() for keyword in content_keywords)
                     
                     if is_content_query:
@@ -4064,7 +4087,7 @@ Given the following conversation history, answer the new user question as best a
             pdf_content_result = collected_data.get("results", {}).get("get_full_pdf_content", {})
             has_pdf_content = pdf_content_result.get("found") and pdf_content_result.get("full_text")
             
-            if has_pdf_content and any(word in original_question.lower() for word in ['summarize', 'findings', 'content', 'main points', 'arguments']):
+            if has_pdf_content and any(word in original_question.lower() for word in ['summarize', 'summary', 'findings', 'content', 'main point', 'main points', 'argument', 'arguments', 'main argument', 'claim', 'claims', 'conclusion', 'conclusions', 'hypothesis', 'hypotheses']):
                 # For content queries with PDF available, use the full PDF text directly
                 pdf_text = pdf_content_result.get("full_text", "")
                 pdf_title = pdf_content_result.get("metadata", {}).get("title", "Unknown Paper")

--- a/src/agents/query_db_agent.py
+++ b/src/agents/query_db_agent.py
@@ -42,16 +42,16 @@ atexit.register(_cleanup_neo4j_driver)
 
 class QueryDBAgent:
     """Agent for querying Neo4j graph database, Qdrant vector database, and PDF documents"""
-    
+
     def __init__(self, config_path: str = "config"):
         """
         Initialize the Query DB Agent with graph and vector database connections.
-        
+
         Args:
             config_path: Path to configuration files
         """
         self.config_manager = ConfigManager(config_path)
-        
+
         # Initialize Graph Database
         try:
             neo4j_config = self.config_manager.neo4j_config
@@ -64,7 +64,7 @@ class QueryDBAgent:
         except Exception as e:
             logging.error(f"Failed to connect to graph database: {e}")
             self.graph_db = None
-        
+
         # Initialize Vector Database
         try:
             self.vector_indexer = VectorIndexer()
@@ -72,7 +72,7 @@ class QueryDBAgent:
         except Exception as e:
             logging.error(f"Failed to connect to vector database: {e}")
             self.vector_indexer = None
-            
+
         # Add papers directory path
         def find_project_root():
             cur = os.path.abspath(os.getcwd())
@@ -84,14 +84,14 @@ class QueryDBAgent:
         self.papers_dir = os.path.join(project_root, "data", "papers")
         if not os.path.exists(self.papers_dir):
             raise FileNotFoundError(f"Papers directory not found: {self.papers_dir}")
-            
+
     def get_metadata_by_paper_id(self, paper_id: str) -> Dict:
         """
         获取指定paper_id的论文元数据
-        
+
         Args:
             paper_id: 论文的唯一标识符
-            
+
         Returns:
             Dict: 论文的完整元数据信息
         """
@@ -99,11 +99,11 @@ class QueryDBAgent:
         if not paper_id:
             logging.error("paper_id cannot be None or empty")
             return {}
-        
+
         if not self.graph_db:
             logging.error("Graph database not available")
             return {}
-        
+
         try:
             query = """
             MATCH (p:Paper {id: $paper_id})
@@ -122,11 +122,11 @@ class QueryDBAgent:
                    p.url as url,
                    p.type as type
             """
-            
+
             with self.graph_db.driver.session() as session:
                 result = session.run(query, paper_id=paper_id)
                 record = result.single()
-                
+
                 if record:
                     paper_metadata = {
                         "paper_id": record["paper_id"],
@@ -144,24 +144,24 @@ class QueryDBAgent:
                         "url": record["url"],
                         "type": record["type"]
                     }
-                    
+
                     logging.info(f"Found metadata for paper {paper_id}")
                     return paper_metadata
                 else:
                     logging.warning(f"No paper found with ID {paper_id}")
                     return {}
-                    
+
         except Exception as e:
             logging.error(f"Error getting metadata for paper {paper_id}: {e}")
             return {}
-    
+
     def get_papers_citing_paper(self, target_paper_id: str) -> List[Dict]:
         """
         获取所有引用了指定论文的论文列表
-        
+
         Args:
             target_paper_id: 被引用论文的ID
-            
+
         Returns:
             List[Dict]: 引用该论文的论文列表，包含paper信息和引用统计
         """
@@ -169,11 +169,11 @@ class QueryDBAgent:
         if not target_paper_id:
             logging.error("target_paper_id cannot be None or empty")
             return []
-        
+
         if not self.graph_db:
             logging.error("Graph database not available")
             return []
-        
+
         try:
             query = """
             MATCH (cited_paper:Paper {id: $target_paper_id})
@@ -191,10 +191,10 @@ class QueryDBAgent:
                    (sentence_citation_count + paragraph_citation_count) as total_citations
             ORDER BY total_citations DESC
             """
-            
+
             with self.graph_db.driver.session() as session:
                 result = session.run(query, target_paper_id=target_paper_id)
-                
+
                 citing_papers = []
                 for record in result:
                     citing_papers.append({
@@ -207,21 +207,21 @@ class QueryDBAgent:
                         "paragraph_citations": record["paragraph_citation_count"],
                         "total_citations": record["total_citations"]
                     })
-                
+
                 logging.info(f"Found {len(citing_papers)} papers citing {target_paper_id}")
                 return citing_papers
-                
+
         except Exception as e:
             logging.error(f"Error getting papers citing {target_paper_id}: {e}")
             return []
-    
+
     def get_papers_cited_by_paper(self, source_paper_id: str) -> List[Dict]:
         """
         获取指定论文引用的所有论文列表
-        
+
         Args:
             source_paper_id: 源论文的ID
-            
+
         Returns:
             List[Dict]: 被该论文引用的论文列表，包含被引用论文信息和引用统计
         """
@@ -229,11 +229,11 @@ class QueryDBAgent:
         if not source_paper_id:
             logging.error("source_paper_id cannot be None or empty")
             return []
-        
+
         if not self.graph_db:
             logging.error("Graph database not available")
             return []
-        
+
         try:
             query = """
             MATCH (source_paper:Paper {id: $source_paper_id})
@@ -252,10 +252,10 @@ class QueryDBAgent:
                    (sentence_citation_count + COALESCE(paragraph_citation_count, 0)) as total_citations
             ORDER BY total_citations DESC
             """
-            
+
             with self.graph_db.driver.session() as session:
                 result = session.run(query, source_paper_id=source_paper_id)
-                
+
                 cited_papers = []
                 for record in result:
                     cited_papers.append({
@@ -269,22 +269,22 @@ class QueryDBAgent:
                         "paragraph_citations": record["paragraph_citation_count"],
                         "total_citations": record["total_citations"]
                     })
-                
+
                 logging.info(f"Found {len(cited_papers)} papers cited by {source_paper_id}")
                 return cited_papers
-                
+
         except Exception as e:
             logging.error(f"Error getting papers cited by {source_paper_id}: {e}")
             return []
-    
+
     def get_paragraphs_citing_paper(self, target_paper_id: str, count: int = -1) -> List[Dict]:
         """
         获取引用了指定论文的段落列表
-        
+
         Args:
             target_paper_id: 被引用论文的ID
             count: 返回段落数量，-1表示全部
-            
+
         Returns:
             List[Dict]: 引用该论文的段落列表，包含段落内容和上下文信息
         """
@@ -292,11 +292,11 @@ class QueryDBAgent:
         if not target_paper_id:
             logging.error("target_paper_id cannot be None or empty")
             return []
-        
+
         if not self.graph_db:
             logging.error("Graph database not available")
             return []
-        
+
         try:
             query = """
             MATCH (cited_paper:Paper {id: $target_paper_id})
@@ -315,10 +315,10 @@ class QueryDBAgent:
                    citing_paper.year as citing_paper_year
             ORDER BY citing_paper.year DESC, paragraph.paragraph_index ASC
             """ + (f"LIMIT {count}" if count > 0 else "")
-            
+
             with self.graph_db.driver.session() as session:
                 result = session.run(query, target_paper_id=target_paper_id)
-                
+
                 citing_paragraphs = []
                 for record in result:
                     citing_paragraphs.append({
@@ -335,22 +335,22 @@ class QueryDBAgent:
                             "year": record["citing_paper_year"]
                         }
                     })
-                
+
                 logging.info(f"Found {len(citing_paragraphs)} paragraphs citing {target_paper_id}")
                 return citing_paragraphs
-                
+
         except Exception as e:
             logging.error(f"Error getting paragraphs citing {target_paper_id}: {e}")
             return []
-    
+
     def get_sentences_citing_paper(self, target_paper_id: str, count: int = -1) -> List[Dict]:
         """
         获取引用了指定论文的句子列表
-        
+
         Args:
             target_paper_id: 被引用论文的ID
             count: 返回句子数量，-1表示全部
-            
+
         Returns:
             List[Dict]: 引用该论文的句子列表，包含句子内容和引用上下文
         """
@@ -358,11 +358,11 @@ class QueryDBAgent:
         if not target_paper_id:
             logging.error("target_paper_id cannot be None or empty")
             return []
-        
+
         if not self.graph_db:
             logging.error("Graph database not available")
             return []
-        
+
         try:
             query = """
             MATCH (cited_paper:Paper {id: $target_paper_id})
@@ -386,10 +386,10 @@ class QueryDBAgent:
                    citing_paper.year as citing_paper_year
             ORDER BY citing_paper.year DESC, sentence.sentence_index ASC
             """ + (f"LIMIT {count}" if count > 0 else "")
-            
+
             with self.graph_db.driver.session() as session:
                 result = session.run(query, target_paper_id=target_paper_id)
-                
+
                 citing_sentences = []
                 for record in result:
                     citing_sentences.append({
@@ -410,28 +410,28 @@ class QueryDBAgent:
                             "year": record["citing_paper_year"]
                         }
                     })
-                
+
                 logging.info(f"Found {len(citing_sentences)} sentences citing {target_paper_id}")
                 return citing_sentences
-                
+
         except Exception as e:
             logging.error(f"Error getting sentences citing {target_paper_id}: {e}")
             return []
-    
-    def get_papers_id_by_title(self, title: str, year: Optional[str] = None, 
-                              authors: Optional[List[str]] = None, 
+
+    def get_papers_id_by_title(self, title: str, year: Optional[str] = None,
+                              authors: Optional[List[str]] = None,
                               journal: Optional[str] = None,
                               similarity_threshold: float = 0.6) -> Dict:
         """
         通过论文标题模糊搜索Paper ID，支持多种搜索场景
-        
+
         Args:
             title: 论文标题（必需）
             year: 发表年份（可选，用于筛选）
             authors: 作者列表（可选，用于筛选）
             journal: 期刊名称（可选，用于筛选）
             similarity_threshold: 相似度阈值（0.0-1.0，默认0.6）
-            
+
         Returns:
             Dict: 搜索结果，包含以下情况：
             - 'status': 'single_match' | 'multiple_matches' | 'no_match'
@@ -444,33 +444,33 @@ class QueryDBAgent:
                 "status": "error",
                 "message": "Graph database not available"
             }
-        
+
         try:
             # 构建查询条件
             query_conditions = []
             query_params = {}
-            
+
             # 基础查询：获取所有论文的元数据（包含stub）
             base_query = """
             MATCH (p:Paper)
             """
-            
+
             # 添加年份筛选
             if year:
                 query_conditions.append("p.year = $year")
                 query_params["year"] = int(year)
-            
+
             # 添加期刊筛选
             if journal:
                 query_conditions.append("toLower(p.journal) CONTAINS toLower($journal)")
                 query_params["journal"] = journal
-            
+
             # 构建完整查询
             if query_conditions:
                 full_query = base_query + " AND " + " AND ".join(query_conditions)
             else:
                 full_query = base_query
-            
+
             full_query += """
             RETURN p.id as paper_id,
                    p.title as title,
@@ -480,29 +480,29 @@ class QueryDBAgent:
                    p.doi as doi
             ORDER BY p.year DESC
             """
-            
+
             with self.graph_db.driver.session() as session:
                 result = session.run(full_query, **query_params)
                 all_papers = [dict(record) for record in result]
-            
+
             if not all_papers:
                 return {
                     "status": "no_match",
                     "message": f"No papers found with the given criteria"
                 }
-            
+
             # 计算标题相似度和子串匹配
             candidates = []
             for paper in all_papers:
                 paper_title = paper.get("title", "")
                 input_title = title
-                
+
                 # 检查子串匹配（高优先级）
                 is_substring_match = self._is_title_substring_match(input_title, paper_title)
-                
+
                 # 计算传统相似度
                 similarity = SequenceMatcher(None, input_title.lower().strip(), paper_title.lower().strip()).ratio()
-                
+
                 # 如果满足任一条件，添加到候选列表
                 if is_substring_match or similarity >= similarity_threshold:
                     candidate = {
@@ -515,7 +515,7 @@ class QueryDBAgent:
                         "similarity_score": round(similarity, 3),
                         "is_substring_match": is_substring_match
                     }
-                    
+
                     # 如果是子串匹配，计算子串匹配置信度
                     if is_substring_match:
                         substring_confidence = self._calculate_substring_match_confidence(input_title, paper_title)
@@ -524,17 +524,17 @@ class QueryDBAgent:
                         candidate["combined_score"] = max(similarity, substring_confidence)
                     else:
                         candidate["combined_score"] = similarity
-                    
+
                     # 如果有作者筛选条件，计算作者匹配度
                     if authors:
                         author_match_score = self._calculate_author_similarity(authors, paper.get("authors", []))
                         candidate["author_match_score"] = round(author_match_score, 3)
-                    
+
                     candidates.append(candidate)
-            
+
             # 按综合分数排序（优先考虑子串匹配）
             candidates.sort(key=lambda x: (x["is_substring_match"], x["combined_score"]), reverse=True)
-            
+
             # 判断搜索结果
             if not candidates:
                 return {
@@ -554,7 +554,7 @@ class QueryDBAgent:
                 # 检查是否有明显的最佳匹配
                 best_candidate = candidates[0]
                 second_best_candidate = candidates[1] if len(candidates) > 1 else None
-                
+
                 # 子串匹配优先
                 if best_candidate["is_substring_match"]:
                     # 如果最佳匹配是子串匹配，且没有其他子串匹配，认为是确定匹配
@@ -566,11 +566,11 @@ class QueryDBAgent:
                             "paper_info": best_candidate,
                             "message": f"Found confident substring match with confidence {best_candidate.get('substring_confidence', 0.0)}"
                         }
-                
+
                 # 传统相似度判断
                 best_score = best_candidate["similarity_score"]
                 second_best_score = second_best_candidate["similarity_score"] if second_best_candidate else 0
-                
+
                 # 如果最佳匹配的相似度比第二名高出0.2以上，认为是确定匹配
                 if best_score - second_best_score >= 0.2 and best_score >= 0.9:
                     return {
@@ -586,30 +586,30 @@ class QueryDBAgent:
                         "count": len(candidates),
                         "message": f"Found {len(candidates)} potential matches. Please specify additional criteria or select manually."
                     }
-                    
+
         except Exception as e:
             logging.error(f"Error in fuzzy title search: {e}")
             return {
                 "status": "error",
                 "message": f"Search failed: {str(e)}"
             }
-    
-    def get_papers_id_by_author(self, author_name: str, 
+
+    def get_papers_id_by_author(self, author_name: str,
                                title_hint: Optional[str] = None,
                                year: Optional[str] = None,
                                case_sensitive: bool = False) -> Dict:
         """
         通过作者姓名Token子集匹配搜索Paper ID
-        
+
         使用Token-based子集匹配：输入的作者名tokens必须是候选作者tokens的子集
         例如: "porter" 能匹配 "Michael E. Porter", "David Porter", 等
-        
+
         Args:
             author_name: 作者姓名或姓名片段
             title_hint: 论文标题提示（可选，用于进一步筛选）
             year: 发表年份（可选）
             case_sensitive: 是否区分大小写（默认false）
-            
+
         Returns:
             Dict: 搜索结果，格式同get_papers_id_by_title
         """
@@ -618,16 +618,16 @@ class QueryDBAgent:
                 "status": "error",
                 "message": "Graph database not available"
             }
-        
+
         try:
             # 构建查询（包含所有论文，无论是否为stub）
             query_conditions = []
             query_params = {}
-            
+
             if year:
                 query_conditions.append("p.year = $year")
                 query_params["year"] = int(year)
-            
+
             # 构建完整查询
             if query_conditions:
                 query = f"""
@@ -652,17 +652,17 @@ class QueryDBAgent:
                        p.doi as doi
                 ORDER BY p.year DESC
                 """
-            
+
             with self.graph_db.driver.session() as session:
                 result = session.run(query, **query_params)
                 all_papers = [dict(record) for record in result]
-            
+
             if not all_papers:
                 return {
                     "status": "no_match",
                     "message": "No papers found with the given criteria"
                 }
-            
+
             # 预处理输入的作者名：分解为tokens
             input_tokens = self._tokenize_author_name(author_name, case_sensitive)
             if not input_tokens:
@@ -670,32 +670,32 @@ class QueryDBAgent:
                     "status": "no_match",
                     "message": "Invalid author name provided"
                 }
-            
+
             # 搜索匹配的作者
             candidates = []
-            
+
             for paper in all_papers:
                 paper_authors = paper.get("authors", [])
                 if not paper_authors:
                     continue
-                
+
                 # 检查每个作者是否匹配
                 matched_authors = []
                 for author in paper_authors:
                     if isinstance(author, str) and author.strip():
                         author_tokens = self._tokenize_author_name(author, case_sensitive)
-                        
+
                         # 检查输入tokens是否为作者tokens的子集
                         if self._is_token_subset(input_tokens, author_tokens):
                             matched_authors.append({
                                 "name": author,
                                 "match_ratio": len(input_tokens) / len(author_tokens) if author_tokens else 0
                             })
-                
+
                 if matched_authors:
                     # 选择匹配度最高的作者
                     best_match = max(matched_authors, key=lambda x: x["match_ratio"])
-                    
+
                     candidate = {
                         "paper_id": paper["paper_id"],
                         "title": paper["title"],
@@ -707,21 +707,21 @@ class QueryDBAgent:
                         "match_ratio": round(best_match["match_ratio"], 3),
                         "all_matched_authors": [m["name"] for m in matched_authors]
                     }
-                    
+
                     # 如果有标题提示，计算标题相似度
                     if title_hint:
                         paper_title = paper.get("title", "").lower().strip()
                         title_similarity = SequenceMatcher(None, title_hint.lower().strip(), paper_title).ratio()
                         candidate["title_similarity_score"] = round(title_similarity, 3)
-                    
+
                     candidates.append(candidate)
-            
+
             # 排序：优先按匹配比例，然后按标题相似度（如果有）
             if title_hint:
                 candidates.sort(key=lambda x: (x["match_ratio"], x.get("title_similarity_score", 0)), reverse=True)
             else:
                 candidates.sort(key=lambda x: x["match_ratio"], reverse=True)
-            
+
             # 判断搜索结果
             if not candidates:
                 return {
@@ -742,168 +742,168 @@ class QueryDBAgent:
                     "count": len(candidates),
                     "message": f"Found {len(candidates)} papers with authors containing '{author_name}'"
                 }
-                
+
         except Exception as e:
             logging.error(f"Error in author token search: {e}")
             return {
                 "status": "error",
                 "message": f"Search failed: {str(e)}"
             }
-    
+
     def _tokenize_author_name(self, author_name: str, case_sensitive: bool = False) -> List[str]:
         """
         将作者姓名分解为tokens
-        
+
         Args:
             author_name: 作者姓名
             case_sensitive: 是否区分大小写
-            
+
         Returns:
             List[str]: 作者姓名的token列表
         """
         if not author_name or not isinstance(author_name, str):
             return []
-        
+
         # 清理字符串：移除多余的标点符号和空格
         cleaned = re.sub(r'[^\w\s.-]', ' ', author_name)
         cleaned = re.sub(r'\s+', ' ', cleaned).strip()
-        
+
         if not case_sensitive:
             cleaned = cleaned.lower()
-        
+
         # 分解为tokens，过滤掉短token (如单字母缩写可能保留)
         tokens = []
         for token in cleaned.split():
             token = token.strip('.-')  # 移除首尾的点和破折号
             if token and len(token) >= 1:  # 保留所有非空token，包括单字母缩写
                 tokens.append(token)
-        
+
         return tokens
-    
+
     def _is_token_subset(self, input_tokens: List[str], candidate_tokens: List[str]) -> bool:
         """
         检查输入tokens是否为候选tokens的子集
-        
+
         Args:
             input_tokens: 输入的token列表
             candidate_tokens: 候选的token列表
-            
+
         Returns:
             bool: 如果输入tokens是候选tokens的子集，返回True
         """
         if not input_tokens:
             return False
-        
+
         if not candidate_tokens:
             return False
-        
+
         # 将所有tokens转换为小写进行比较
         input_set = {token.lower() for token in input_tokens}
         candidate_set = {token.lower() for token in candidate_tokens}
-        
+
         # 检查是否为子集
         return input_set.issubset(candidate_set)
-    
+
     def _calculate_author_similarity(self, input_authors: List[str], paper_authors: List[str]) -> float:
         """
         计算输入作者列表与论文作者列表的相似度
-        
+
         Args:
             input_authors: 输入的作者列表
             paper_authors: 论文的作者列表
-            
+
         Returns:
             float: 相似度分数（0.0-1.0）
         """
         if not input_authors or not paper_authors:
             return 0.0
-        
+
         total_similarity = 0
         matched_count = 0
-        
+
         for input_author in input_authors:
             input_clean = input_author.lower().strip()
             max_similarity = 0
-            
+
             for paper_author in paper_authors:
                 if isinstance(paper_author, str):
                     paper_clean = paper_author.lower().strip()
                     similarity = SequenceMatcher(None, input_clean, paper_clean).ratio()
                     max_similarity = max(max_similarity, similarity)
-            
+
             if max_similarity > 0.7:  # 只计算相似度较高的匹配
                 total_similarity += max_similarity
                 matched_count += 1
-        
+
         if matched_count == 0:
             return 0.0
-        
+
         # 返回平均相似度，但对匹配数量进行权重调整
         average_similarity = total_similarity / matched_count
         coverage_bonus = min(matched_count / len(input_authors), 1.0) * 0.2
-        
+
         return min(average_similarity + coverage_bonus, 1.0)
 
     def _is_title_substring_match(self, input_title: str, paper_title: str, min_length: int = 5) -> bool:
         """
         检查输入标题是否为论文标题的子串匹配
-        
+
         Args:
             input_title: 输入的标题
             paper_title: 论文的完整标题
             min_length: 最小匹配长度阈值
-            
+
         Returns:
             bool: 如果输入标题是论文标题的子串且长度满足要求，返回True
         """
         if not input_title or not paper_title:
             return False
-        
+
         # 标准化处理：转换为小写并清理
         input_clean = input_title.lower().strip()
         paper_clean = paper_title.lower().strip()
-        
+
         # 检查长度阈值
         if len(input_clean) < min_length:
             return False
-        
+
         # 检查是否为子串
         return input_clean in paper_clean
 
     def _calculate_substring_match_confidence(self, input_title: str, paper_title: str) -> float:
         """
         计算子串匹配的置信度分数
-        
+
         Args:
             input_title: 输入的标题
             paper_title: 论文的完整标题
-            
+
         Returns:
             float: 置信度分数（0.0-1.0）
         """
         if not input_title or not paper_title:
             return 0.0
-        
+
         input_clean = input_title.lower().strip()
         paper_clean = paper_title.lower().strip()
-        
+
         # 基础分数：子串长度占完整标题的比例
         length_ratio = len(input_clean) / len(paper_clean)
-        
+
         # 位置奖励：如果子串在标题开头，给予额外奖励
         position_bonus = 0.0
         if paper_clean.startswith(input_clean):
             position_bonus = 0.1
-        
+
         # 长度奖励：较长的子串获得更高分数
         length_bonus = min(length_ratio * 0.2, 0.2)
-        
+
         # 计算最终置信度
         confidence = length_ratio + position_bonus + length_bonus
-        
+
         return min(confidence, 1.0)
 
-    def search_relevant_sentences(self, text: str, top_n: int = 50, 
+    def search_relevant_sentences(self, text: str, top_n: int = 50,
                                  paper_ids: Optional[List[str]] = None,
                                  min_score: float = 0.0,
                                  years: Optional[List[int]] = None,
@@ -911,7 +911,7 @@ class QueryDBAgent:
                                  sentence_types: Optional[List[str]] = None) -> Dict:
         """
         在向量数据库中搜索与给定文本最相关的句子
-        
+
         Args:
             text: 查询文本
             top_n: 返回结果数量 (默认50)
@@ -920,7 +920,7 @@ class QueryDBAgent:
             years: 限制搜索的年份列表 (可选)
             journals: 限制搜索的期刊列表 (可选)
             sentence_types: 限制搜索的句子类型 (可选)
-            
+
         Returns:
             Dict: 搜索结果包含匹配的句子及其元数据
         """
@@ -929,31 +929,31 @@ class QueryDBAgent:
                 "status": "error",
                 "message": "Vector database not available"
             }
-        
+
         try:
             # 构建过滤条件
             filter_conditions = {}
-            
+
             if paper_ids:
                 filter_conditions["paper_id"] = {"$in": paper_ids}
-            
+
             if years:
                 filter_conditions["year"] = {"$in": years}
-            
+
             if journals:
                 # 使用模糊匹配处理期刊名称
                 filter_conditions["journal"] = {"$in": journals}
-            
+
             if sentence_types:
                 filter_conditions["sentence_type"] = {"$in": sentence_types}
-            
+
             # 执行向量搜索
             search_results = self.vector_indexer.search(
                 query=text,
                 collection_name="sentences",
                 limit=min(top_n * 2, 200)  # 搜索更多结果以便过滤
             )
-            
+
             if not search_results:
                 return {
                     "status": "no_match",
@@ -961,10 +961,10 @@ class QueryDBAgent:
                     "query": text,
                     "total_results": 0
                 }
-            
+
             # 过滤结果 (如果有过滤条件)
             filtered_results = search_results
-            
+
             if filter_conditions:
                 filtered_results = []
                 for result in search_results:
@@ -980,7 +980,7 @@ class QueryDBAgent:
                     if result.get("score", 0.0) < min_score:
                         continue
                     filtered_results.append(result)
-            
+
             # 处理搜索结果
             processed_results = []
             for result in filtered_results[:top_n]:
@@ -1002,7 +1002,7 @@ class QueryDBAgent:
                     }
                 }
                 processed_results.append(processed_result)
-            
+
             return {
                 "status": "success",
                 "message": f"Found {len(processed_results)} relevant sentences",
@@ -1012,7 +1012,7 @@ class QueryDBAgent:
                 "min_score": processed_results[-1]["score"] if processed_results else 0.0,
                 "results": processed_results
             }
-            
+
         except Exception as e:
             logging.error(f"Error in sentence search: {e}")
             return {
@@ -1020,7 +1020,7 @@ class QueryDBAgent:
                 "message": f"Search failed: {str(e)}",
                 "query": text
             }
-    
+
     def search_relevant_paragraphs(self, text: str, top_n: int = 50,
                                   paper_ids: Optional[List[str]] = None,
                                   min_score: float = 0.0,
@@ -1030,7 +1030,7 @@ class QueryDBAgent:
                                   has_citations: Optional[bool] = None) -> Dict:
         """
         在向量数据库中搜索与给定文本最相关的段落
-        
+
         Args:
             text: 查询文本
             top_n: 返回结果数量 (默认50)
@@ -1040,42 +1040,42 @@ class QueryDBAgent:
             journals: 限制搜索的期刊列表 (可选)
             sections: 限制搜索的章节列表 (可选，如"introduction", "methodology")
             has_citations: 是否包含引用 (可选)
-            
+
         Returns:
             Dict: 搜索结果包含匹配的段落及其元数据
         """
         if not self.vector_indexer:
             return {
-                "status": "error", 
+                "status": "error",
                 "message": "Vector database not available"
             }
-        
+
         try:
             # 构建过滤条件
             filter_conditions = {}
-            
+
             if paper_ids:
                 filter_conditions["paper_id"] = {"$in": paper_ids}
-            
+
             if years:
                 filter_conditions["year"] = {"$in": years}
-            
+
             if journals:
                 filter_conditions["journal"] = {"$in": journals}
-            
+
             if sections:
                 filter_conditions["section"] = {"$in": sections}
-            
+
             if has_citations is not None:
                 filter_conditions["has_citations"] = has_citations
-            
+
             # 执行向量搜索
             search_results = self.vector_indexer.search(
                 query=text,
                 collection_name="paragraphs",
                 limit=min(top_n * 2, 200)
             )
-            
+
             if not search_results:
                 return {
                     "status": "no_match",
@@ -1083,10 +1083,10 @@ class QueryDBAgent:
                     "query": text,
                     "total_results": 0
                 }
-            
+
             # 过滤结果 (如果有过滤条件)
             filtered_results = search_results
-            
+
             if filter_conditions:
                 filtered_results = []
                 for result in search_results:
@@ -1104,7 +1104,7 @@ class QueryDBAgent:
                     if result.get("score", 0.0) < min_score:
                         continue
                     filtered_results.append(result)
-            
+
             # 处理搜索结果
             processed_results = []
             for result in filtered_results[:top_n]:
@@ -1132,7 +1132,7 @@ class QueryDBAgent:
                     }
                 }
                 processed_results.append(processed_result)
-            
+
             return {
                 "status": "success",
                 "message": f"Found {len(processed_results)} relevant paragraphs",
@@ -1142,7 +1142,7 @@ class QueryDBAgent:
                 "min_score": processed_results[-1]["score"] if processed_results else 0.0,
                 "results": processed_results
             }
-            
+
         except Exception as e:
             logging.error(f"Error in paragraph search: {e}")
             return {
@@ -1150,7 +1150,7 @@ class QueryDBAgent:
                 "message": f"Search failed: {str(e)}",
                 "query": text
             }
-    
+
     def search_relevant_sections(self, text: str, top_n: int = 50,
                                 paper_ids: Optional[List[str]] = None,
                                 min_score: float = 0.0,
@@ -1159,7 +1159,7 @@ class QueryDBAgent:
                                 section_types: Optional[List[str]] = None) -> Dict:
         """
         在向量数据库中搜索与给定文本最相关的章节
-        
+
         Args:
             text: 查询文本
             top_n: 返回结果数量 (默认50)
@@ -1168,7 +1168,7 @@ class QueryDBAgent:
             years: 限制搜索的年份列表 (可选)
             journals: 限制搜索的期刊列表 (可选)
             section_types: 限制搜索的章节类型 (可选，如"introduction", "methodology", "conclusion")
-            
+
         Returns:
             Dict: 搜索结果包含匹配的章节及其元数据
         """
@@ -1177,30 +1177,30 @@ class QueryDBAgent:
                 "status": "error",
                 "message": "Vector database not available"
             }
-        
+
         try:
             # 构建过滤条件
             filter_conditions = {}
-            
+
             if paper_ids:
                 filter_conditions["paper_id"] = {"$in": paper_ids}
-            
+
             if years:
                 filter_conditions["year"] = {"$in": years}
-            
+
             if journals:
                 filter_conditions["journal"] = {"$in": journals}
-            
+
             if section_types:
                 filter_conditions["type"] = {"$in": section_types}
-            
+
             # 执行向量搜索
             search_results = self.vector_indexer.search(
                 query=text,
                 collection_name="sections",
                 limit=min(top_n * 2, 200)
             )
-            
+
             if not search_results:
                 return {
                     "status": "no_match",
@@ -1208,10 +1208,10 @@ class QueryDBAgent:
                     "query": text,
                     "total_results": 0
                 }
-            
+
             # 过滤结果 (如果有过滤条件)
             filtered_results = search_results
-            
+
             if filter_conditions:
                 filtered_results = []
                 for result in search_results:
@@ -1227,7 +1227,7 @@ class QueryDBAgent:
                     if result.get("score", 0.0) < min_score:
                         continue
                     filtered_results.append(result)
-            
+
             # 处理搜索结果
             processed_results = []
             for result in filtered_results[:top_n]:
@@ -1253,7 +1253,7 @@ class QueryDBAgent:
                     }
                 }
                 processed_results.append(processed_result)
-            
+
             return {
                 "status": "success",
                 "message": f"Found {len(processed_results)} relevant sections",
@@ -1263,7 +1263,7 @@ class QueryDBAgent:
                 "min_score": processed_results[-1]["score"] if processed_results else 0.0,
                 "results": processed_results
             }
-            
+
         except Exception as e:
             logging.error(f"Error in section search: {e}")
             return {
@@ -1271,21 +1271,21 @@ class QueryDBAgent:
                 "message": f"Search failed: {str(e)}",
                 "query": text
             }
-    
+
     def search_all_content_types(self, text: str, top_n_per_type: int = 20,
                                 min_score: float = 0.0,
                                 paper_ids: Optional[List[str]] = None,
                                 years: Optional[List[int]] = None) -> Dict:
         """
         跨所有内容类型（句子、段落、章节）进行综合搜索
-        
+
         Args:
             text: 查询文本
             top_n_per_type: 每种类型返回的结果数量
             min_score: 最小相似度分数阈值
             paper_ids: 限制搜索的论文ID列表 (可选)
             years: 限制搜索的年份列表 (可选)
-            
+
         Returns:
             Dict: 包含所有类型搜索结果的综合报告
         """
@@ -1294,22 +1294,22 @@ class QueryDBAgent:
             sentences_result = self.search_relevant_sentences(
                 text, top_n_per_type, paper_ids, min_score, years
             )
-            
+
             paragraphs_result = self.search_relevant_paragraphs(
                 text, top_n_per_type, paper_ids, min_score, years
             )
-            
+
             sections_result = self.search_relevant_sections(
                 text, top_n_per_type, paper_ids, min_score, years
             )
-            
+
             # 统计总结果
             total_results = (
                 sentences_result.get("total_results", 0) +
                 paragraphs_result.get("total_results", 0) +
                 sections_result.get("total_results", 0)
             )
-            
+
             # 找出最高分数
             max_scores = [
                 sentences_result.get("max_score", 0.0),
@@ -1317,7 +1317,7 @@ class QueryDBAgent:
                 sections_result.get("max_score", 0.0)
             ]
             overall_max_score = max(max_scores) if max_scores else 0.0
-            
+
             return {
                 "status": "success",
                 "message": f"Comprehensive search completed: {total_results} total results",
@@ -1333,7 +1333,7 @@ class QueryDBAgent:
                 "paragraphs": paragraphs_result,
                 "sections": sections_result
             }
-            
+
         except Exception as e:
             logging.error(f"Error in comprehensive search: {e}")
             return {
@@ -1344,12 +1344,12 @@ class QueryDBAgent:
 
     def query_pdf_content(self, paper_id: str, query: str, context_window: int = 500) -> Dict[str, Any]:
         """Query PDF content directly using the stored processed document
-        
+
         Args:
             paper_id: The paper ID to query
             query: The question or search query
             context_window: Number of characters around matching text to include
-            
+
         Returns:
             Dict containing relevant content from the PDF
         """
@@ -1360,56 +1360,56 @@ class QueryDBAgent:
                 "error": "paper_id cannot be None or empty",
                 "data": []
             }
-        
+
         try:
             paper_path = os.path.join(self.papers_dir, paper_id)
             processed_doc_path = os.path.join(paper_path, "processed_document.json")
-            
+
             if not os.path.exists(processed_doc_path):
                 return {
                     "found": False,
                     "error": f"Processed document not found for paper {paper_id}",
                     "data": []
                 }
-            
+
             # Load the processed document
             with open(processed_doc_path, 'r', encoding='utf-8') as f:
                 doc_data = json.load(f)
-            
+
             # Search through sections
             relevant_content = []
             query_lower = query.lower()
-            
+
             for section in doc_data.get("sections", []):
-                section_text = section.get("section_text", "")
-                section_title = section.get("section_title", "")
-                
+                section_text = section.get("section_text", "") or section.get("text", "")
+                section_title = section.get("section_title", "") or section.get("title", "")
+
                 # Simple keyword matching (can be enhanced with semantic search)
                 if query_lower in section_text.lower() or query_lower in section_title.lower():
                     # Find specific matches within the section
                     text_lower = section_text.lower()
                     matches = []
                     start_pos = 0
-                    
+
                     while True:
                         pos = text_lower.find(query_lower, start_pos)
                         if pos == -1:
                             break
-                        
+
                         # Extract context around the match
                         context_start = max(0, pos - context_window//2)
                         context_end = min(len(section_text), pos + len(query) + context_window//2)
                         context = section_text[context_start:context_end]
-                        
+
                         matches.append({
                             "position": pos,
                             "context": context.strip(),
                             "highlight_start": pos - context_start,
                             "highlight_end": pos - context_start + len(query)
                         })
-                        
+
                         start_pos = pos + 1
-                    
+
                     if matches:
                         relevant_content.append({
                             "section_index": section.get("section_index"),
@@ -1419,7 +1419,7 @@ class QueryDBAgent:
                             "word_count": section.get("word_count", 0),
                             "citations": section.get("citations", [])
                         })
-            
+
             return {
                 "found": len(relevant_content) > 0,
                 "paper_id": paper_id,
@@ -1428,29 +1428,44 @@ class QueryDBAgent:
                 "total_matches": sum(len(section["matches"]) for section in relevant_content),
                 "data": relevant_content
             }
-            
+
         except Exception as e:
             return {
                 "found": False,
                 "error": f"Error querying PDF content: {str(e)}",
                 "data": []
             }
-    
+
+    def _extract_search_candidates(self, search_result: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Normalize fuzzy search results into a flat candidate list."""
+        if not search_result or not isinstance(search_result, dict):
+            return []
+
+        status = search_result.get("status")
+        if status == "single_match":
+            paper_info = search_result.get("paper_info")
+            return [paper_info] if isinstance(paper_info, dict) else []
+        if status == "multiple_matches":
+            candidates = search_result.get("candidates", [])
+            return [candidate for candidate in candidates if isinstance(candidate, dict)]
+        return []
+
     def query_pdf_by_title_and_content(self, title_query: str, content_query: str) -> Dict[str, Any]:
         """Find papers by title and then query their content
-        
+
         Args:
             title_query: Query to find papers by title
             content_query: Query to search within the found papers
-            
+
         Returns:
             Dict containing papers and their relevant content
         """
         try:
             # First find papers by title
             title_results = self.get_papers_id_by_title(title_query)
-            
-            if not title_results.get("found") or not title_results.get("data"):
+            candidate_papers = self._extract_search_candidates(title_results)
+
+            if not candidate_papers:
                 return {
                     "found": False,
                     "error": "No papers found matching the title query",
@@ -1458,10 +1473,10 @@ class QueryDBAgent:
                     "content_query": content_query,
                     "data": []
                 }
-            
+
             # Query content in each found paper
             content_results = []
-            for paper in title_results["data"]:
+            for paper in candidate_papers:
                 paper_id = paper.get("paper_id")
                 if paper_id:
                     content_result = self.query_pdf_content(paper_id, content_query)
@@ -1470,38 +1485,39 @@ class QueryDBAgent:
                             "paper_metadata": paper,
                             "content_matches": content_result
                         })
-            
+
             return {
                 "found": len(content_results) > 0,
                 "title_query": title_query,
                 "content_query": content_query,
-                "papers_found": len(title_results["data"]),
+                "papers_found": len(candidate_papers),
                 "papers_with_content": len(content_results),
                 "data": content_results
             }
-            
+
         except Exception as e:
             return {
                 "found": False,
                 "error": f"Error in title and content query: {str(e)}",
                 "data": []
             }
-    
+
     def query_pdf_by_author_and_content(self, author_name: str, content_query: str) -> Dict[str, Any]:
         """Find papers by author and then query their content
-        
+
         Args:
             author_name: Author name to search for
             content_query: Query to search within the found papers
-            
+
         Returns:
             Dict containing papers and their relevant content
         """
         try:
             # First find papers by author
             author_results = self.get_papers_id_by_author(author_name)
-            
-            if not author_results.get("found") or not author_results.get("data"):
+            candidate_papers = self._extract_search_candidates(author_results)
+
+            if not candidate_papers:
                 return {
                     "found": False,
                     "error": f"No papers found for author: {author_name}",
@@ -1509,10 +1525,10 @@ class QueryDBAgent:
                     "content_query": content_query,
                     "data": []
                 }
-            
+
             # Query content in each found paper
             content_results = []
-            for paper in author_results["data"]:
+            for paper in candidate_papers:
                 paper_id = paper.get("paper_id")
                 if paper_id:
                     content_result = self.query_pdf_content(paper_id, content_query)
@@ -1521,29 +1537,29 @@ class QueryDBAgent:
                             "paper_metadata": paper,
                             "content_matches": content_result
                         })
-            
+
             return {
                 "found": len(content_results) > 0,
                 "author_name": author_name,
                 "content_query": content_query,
-                "papers_found": len(author_results["data"]),
+                "papers_found": len(candidate_papers),
                 "papers_with_content": len(content_results),
                 "data": content_results
             }
-            
+
         except Exception as e:
             return {
                 "found": False,
                 "error": f"Error in author and content query: {str(e)}",
                 "data": []
             }
-    
+
     def get_full_pdf_content(self, paper_id: str) -> Dict[str, Any]:
         """Get the complete content of a PDF paper
-        
+
         Args:
             paper_id: The paper ID
-            
+
         Returns:
             Dict containing the full paper content
         """
@@ -1554,70 +1570,76 @@ class QueryDBAgent:
                 "error": "paper_id cannot be None or empty",
                 "data": {}
             }
-        
+
         try:
             paper_path = os.path.join(self.papers_dir, paper_id)
             processed_doc_path = os.path.join(paper_path, "processed_document.json")
-            
+
             if not os.path.exists(processed_doc_path):
                 return {
                     "found": False,
                     "error": f"Processed document not found for paper {paper_id}",
                     "data": {}
                 }
-            
+
             # Load the complete processed document
             with open(processed_doc_path, 'r', encoding='utf-8') as f:
                 doc_data = json.load(f)
-            
+
             # Extract full text from all sections
             full_text_parts = []
             section_summaries = []
-            
+            total_word_count = 0
+
             for section in doc_data.get("sections", []):
-                section_text = section.get("section_text", "")
-                section_title = section.get("section_title", "")
-                
+                section_text = section.get("section_text", "") or section.get("text", "")
+                section_title = section.get("section_title", "") or section.get("title", "")
+                section_type = section.get("section_type", section.get("type", ""))
+                section_index = section.get("section_index", section.get("index", 0))
+                word_count = section.get("word_count", len(section_text.split()))
+                citation_count = len(section.get("citations", []))
+
                 if section_text:
+                    total_word_count += word_count
                     full_text_parts.append(f"## {section_title}\n\n{section_text}")
-                    
+
                     section_summaries.append({
-                        "section_index": section.get("section_index"),
+                        "section_index": section_index,
                         "section_title": section_title,
-                        "section_type": section.get("section_type"),
-                        "word_count": section.get("word_count", 0),
-                        "citations_count": len(section.get("citations", [])),
+                        "section_type": section_type,
+                        "word_count": word_count,
+                        "citations_count": citation_count,
                         "preview": section_text[:200] + "..." if len(section_text) > 200 else section_text
                     })
-            
+
             full_text = "\n\n".join(full_text_parts)
-            
+
             return {
                 "found": True,
                 "paper_id": paper_id,
                 "metadata": doc_data.get("metadata", {}),
                 "sections_count": len(doc_data.get("sections", [])),
-                "total_word_count": sum(section.get("word_count", 0) for section in doc_data.get("sections", [])),
+                "total_word_count": total_word_count,
                 "section_summaries": section_summaries,
                 "full_text": full_text,
                 "data": doc_data
             }
-            
+
         except Exception as e:
             return {
                 "found": False,
                 "error": f"Error retrieving full PDF content: {str(e)}",
                 "data": {}
             }
-    
+
     def semantic_search_pdf_content(self, paper_id: str, query: str, similarity_threshold: float = 0.5) -> Dict[str, Any]:
         """Perform semantic search within a specific PDF using sentence transformers
-        
+
         Args:
             paper_id: The paper ID to search within
             query: The search query
             similarity_threshold: Minimum similarity score for results
-            
+
         Returns:
             Dict containing semantically similar content
         """
@@ -1628,32 +1650,32 @@ class QueryDBAgent:
                 "error": "paper_id cannot be None or empty",
                 "data": []
             }
-        
+
         try:
             # Get the full PDF content first
             pdf_result = self.get_full_pdf_content(paper_id)
-            
+
             if not pdf_result.get("found"):
                 return pdf_result
-            
+
             # Try to use sentence transformers for semantic search
             try:
                 from sentence_transformers import SentenceTransformer
                 import numpy as np
                 from sklearn.metrics.pairwise import cosine_similarity
-                
+
                 # Initialize the model (use a lightweight model)
                 model = SentenceTransformer('all-MiniLM-L6-v2')
-                
+
                 # Split content into chunks for semantic search
                 sections = pdf_result["data"].get("sections", [])
                 chunks = []
                 chunk_metadata = []
-                
+
                 for section in sections:
-                    section_text = section.get("section_text", "")
-                    section_title = section.get("section_title", "")
-                    
+                    section_text = section.get("section_text", "") or section.get("text", "")
+                    section_title = section.get("section_title", "") or section.get("title", "")
+
                     # Split long sections into smaller chunks
                     if len(section_text) > 1000:
                         # Split by paragraphs or sentences
@@ -1675,25 +1697,25 @@ class QueryDBAgent:
                             "paragraph_index": 0,
                             "chunk_type": "full_section"
                         })
-                
+
                 if not chunks:
                     return {
                         "found": False,
                         "error": "No content chunks found for semantic search",
                         "data": []
                     }
-                
+
                 # Encode query and chunks
                 query_embedding = model.encode([query])
                 chunk_embeddings = model.encode(chunks)
-                
+
                 # Calculate similarities
                 similarities = cosine_similarity(query_embedding, chunk_embeddings)[0]
-                
+
                 # Filter by threshold and sort by similarity
                 relevant_indices = [i for i, sim in enumerate(similarities) if sim >= similarity_threshold]
                 relevant_indices.sort(key=lambda i: similarities[i], reverse=True)
-                
+
                 # Prepare results
                 semantic_results = []
                 for idx in relevant_indices[:10]:  # Top 10 results
@@ -1702,7 +1724,7 @@ class QueryDBAgent:
                         "similarity_score": float(similarities[idx]),
                         "metadata": chunk_metadata[idx]
                     })
-                
+
                 return {
                     "found": len(semantic_results) > 0,
                     "paper_id": paper_id,
@@ -1712,11 +1734,11 @@ class QueryDBAgent:
                     "relevant_chunks_found": len(semantic_results),
                     "data": semantic_results
                 }
-                
+
             except ImportError:
                 # Fallback to keyword search if sentence transformers not available
                 return self.query_pdf_content(paper_id, query)
-                
+
         except Exception as e:
             return {
                 "found": False,
@@ -1738,16 +1760,16 @@ class QueryDBAgent:
 # 测试用例
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    
+
     # 初始化Query Agent
     agent = QueryDBAgent()
-    
+
     print("=== Query DB Agent 完整测试 ===\n")
-    
+
     # ==================== 第一部分：Fuzzy Search 测试 ====================
     print("📚 第一部分：Fuzzy Search 模糊搜索测试")
     print("=" * 60)
-    
+
     # 测试1: 按标题搜索（完全匹配）
     print("\n1. 测试标题精确搜索:")
     title_result = agent.get_papers_id_by_title("Technology search strategies and competition due to import penetration")
@@ -1760,7 +1782,7 @@ if __name__ == "__main__":
         print(f"   找到 {title_result['count']} 个候选:")
         for i, candidate in enumerate(title_result['candidates'][:3]):
             print(f"     {i+1}. {candidate['title']} ({candidate['year']}) - 相似度: {candidate['similarity_score']}")
-    
+
     # # 测试2: 按标题搜索（部分匹配）
     # print("\n2. 测试标题模糊搜索:")
     # fuzzy_title_result = agent.get_papers_id_by_title("imitation complex")
@@ -1773,7 +1795,7 @@ if __name__ == "__main__":
     # else:
     #     print(f"   搜索结果: {fuzzy_title_result['status']}")
     #     print(f"   消息: {fuzzy_title_result['message']}")
-    
+
     # # 测试3: 按作者搜索 (Token子集匹配)
     # print("\n3. 测试作者Token搜索:")
     # author_result = agent.get_papers_id_by_author("Porter")
@@ -1788,7 +1810,7 @@ if __name__ == "__main__":
     # else:
     #     print(f"   搜索结果: {author_result['status']}")
     #     print(f"   消息: {author_result['message']}")
-    
+
     # # 测试4: 部分名字搜索
     # print("\n4. 测试部分作者名搜索:")
     # partial_result = agent.get_papers_id_by_author("michael")
@@ -1801,7 +1823,7 @@ if __name__ == "__main__":
     # else:
     #     print(f"   搜索结果: {partial_result['status']}")
     #     print(f"   消息: {partial_result['message']}")
-    
+
     # # 测试5: 组合搜索（作者+标题提示）
     # print("\n5. 测试组合搜索 (作者+标题提示):")
     # combo_result = agent.get_papers_id_by_author("Porter", title_hint="competitive", year="1980")
@@ -1817,14 +1839,14 @@ if __name__ == "__main__":
     # else:
     #     print(f"   搜索结果: {combo_result['status']}")
     #     print(f"   消息: {combo_result['message']}")
-    
+
     # # 测试6: 测试Token化功能
     # print("\n6. 测试Token化功能:")
     # test_names = ["Michael E. Porter", "J.R.R. Tolkien", "Mary O'Connor", "Van Der Berg"]
     # for name in test_names:
     #     tokens = agent._tokenize_author_name(name)
     #     print(f"   '{name}' -> tokens: {tokens}")
-    
+
     # # 测试7: 测试子集匹配
     # print("\n7. 测试子集匹配:")
     # test_cases = [
@@ -1836,11 +1858,11 @@ if __name__ == "__main__":
     # for input_tokens, candidate_tokens in test_cases:
     #     is_subset = agent._is_token_subset(input_tokens, candidate_tokens)
     #     print(f"   {input_tokens} ⊆ {candidate_tokens} = {is_subset}")
-    
+
     # # ==================== 第二部分：使用找到的Paper ID进行详细查询 ====================
     # print("\n\n📖 第二部分：使用找到的Paper ID进行详细查询")
     # print("=" * 60)
-    
+
     # # 获取一个实际的paper ID用于测试
     # test_paper_id = "babcd89569ffe6cb373ed21a762c1799ace907d68f5cffa189e2d6be77af0504"
     # # if title_result['status'] == 'single_match':
@@ -1849,10 +1871,10 @@ if __name__ == "__main__":
     # #     test_paper_id = combo_result['paper_id']
     # # elif title_result['status'] == 'multiple_matches' and title_result['candidates']:
     # #     test_paper_id = title_result['candidates'][0]['paper_id']
-    
+
     # if test_paper_id:
     #     print(f"\n使用Paper ID进行测试: {test_paper_id}")
-        
+
     #     # 测试5: 获取论文元数据
     #     print("\n5. 测试获取论文元数据:")
     #     metadata = agent.get_metadata_by_paper_id(test_paper_id)
@@ -1862,21 +1884,21 @@ if __name__ == "__main__":
     #         print(f"   年份: {metadata.get('year', 'N/A')}")
     #         print(f"   期刊: {metadata.get('journal', 'N/A')}")
     #         print(f"   是否为存根: {metadata.get('is_stub', 'N/A')}")
-        
+
     #     # 测试6: 获取引用该论文的所有论文
     #     print("\n6. 测试获取引用该论文的论文:")
     #     citing_papers = agent.get_papers_citing_paper(test_paper_id)
     #     print(f"   找到 {len(citing_papers)} 篇论文引用了该论文")
     #     for paper in citing_papers[:2]:  # 显示前2个
     #         print(f"   - {paper['title']} ({paper['year']}): {paper['total_citations']} 引用")
-        
+
     #     # 测试7: 获取该论文引用的所有论文
     #     print("\n7. 测试获取该论文引用的论文:")
     #     cited_papers = agent.get_papers_cited_by_paper(test_paper_id)
     #     print(f"   该论文引用了 {len(cited_papers)} 篇论文")
     #     for paper in cited_papers[:2]:  # 显示前2个
     #         print(f"   - {paper['title']} ({paper['year']}): {paper['total_citations']} 次引用")
-        
+
     #     # 测试8: 获取引用该论文的句子（限制5个）
     #     print("\n8. 测试获取引用句子:")
     #     citing_sentences = agent.get_sentences_citing_paper(test_paper_id, count=5)
@@ -1887,18 +1909,18 @@ if __name__ == "__main__":
     #             print(f"     引用文本: {sent['citation_text']}")
     # else:
     #     print("\n⚠️  没有找到可用的Paper ID进行详细查询测试")
-    
+
     # print("\n🏁 完整测试完成!")
-    
+
     # # ==================== 第三部分：向量搜索测试 ====================
     # print("\n\n🔍 第三部分：向量数据库语义搜索测试")
     # print("=" * 60)
-    
+
     # # 测试9: 句子级语义搜索
     # print("\n9. 测试句子语义搜索:")
     # sentence_search = agent.search_relevant_sentences(
-    #     "competitive strategy and market positioning", 
-    #     top_n=5, 
+    #     "competitive strategy and market positioning",
+    #     top_n=5,
     #     min_score=0.3
     # )
     # print(f"   搜索结果: {sentence_search['status']}")
@@ -1910,8 +1932,8 @@ if __name__ == "__main__":
     #         print(f"     {i+1}. 分数: {result['score']}")
     #         print(f"        文本: {result['text'][:80]}...")
     #         print(f"        来源: {result['paper_info']['title']}")
-    
-    # # 测试10: 段落级语义搜索 
+
+    # # 测试10: 段落级语义搜索
     # print("\n10. 测试段落语义搜索:")
     # paragraph_search = agent.search_relevant_paragraphs(
     #     "innovation and organizational change",
@@ -1928,7 +1950,7 @@ if __name__ == "__main__":
     #         print(f"        段落: {result['text']}")
     #         print(f"        章节: {result['paragraph_metadata']['section']}")
     #         print(f"        引用数: {result['paragraph_metadata']['citation_count']}")
-    
+
     # # 测试11: 章节级语义搜索
     # print("\n11. 测试章节语义搜索:")
     # section_search = agent.search_relevant_sections(
@@ -1946,7 +1968,7 @@ if __name__ == "__main__":
     #         print(f"        章节标题: {result['title']}")
     #         print(f"        章节类型: {result['section_metadata']['section_type']}")
     #         print(f"        内容预览: {result['text'][:100]}...")
-    
+
     # # 测试12: 综合搜索
     # print("\n12. 测试综合语义搜索:")
     # comprehensive_search = agent.search_all_content_types(
@@ -1962,16 +1984,16 @@ if __name__ == "__main__":
     #     print(f"     总结果数: {stats['total_results']}")
     #     print(f"     最高分数: {stats['max_score']}")
     #     print(f"     句子: {stats['sentences_count']} 个")
-    #     print(f"     段落: {stats['paragraphs_count']} 个") 
+    #     print(f"     段落: {stats['paragraphs_count']} 个")
     #     print(f"     章节: {stats['sections_count']} 个")
-        
+
     #     # 显示每种类型的最佳结果
     #     for content_type in ['sentences', 'paragraphs', 'sections']:
     #         type_results = comprehensive_search[content_type]
     #         if type_results['status'] == 'success' and type_results['results']:
     #             best = type_results['results'][0]
     #             print(f"     最佳{content_type[:-1]}: {best['score']} - {best['text'][:50]}...")
-    
+
     # # 测试13: 带过滤条件的搜索
     # if test_paper_id:
     #     print("\n13. 测试带过滤条件的搜索:")
@@ -1985,6 +2007,6 @@ if __name__ == "__main__":
     #     print(f"   消息: {filtered_search['message']}")
     #     if filtered_search['status'] == 'success':
     #         print(f"   在特定论文中找到 {filtered_search['total_results']} 个相关句子")
-    
+
     # print("\n🎉 向量搜索测试完成!")
-    # agent.close() 
+    # agent.close()

--- a/src/agents/routing.py
+++ b/src/agents/routing.py
@@ -12,6 +12,7 @@ Expected formats:
     CITEWEAVE_ROUTE_ALIASES = {"alias_name": "route_name"}
     CITEWEAVE_ROUTE_ADDON_CONFIG = /path/to/route-config.json
     CITEWEAVE_ROUTE_ADDON_CONFIG = /path/base-route-config.json:/path/overlay-route-config.json
+    CITEWEAVE_ROUTE_ADDON_CONFIG = /path/base-route-config.json:/path/route-overrides.d
 
 When addon config file(s) are present, each accepts:
     {
@@ -21,6 +22,8 @@ When addon config file(s) are present, each accepts:
 
 When multiple config files are provided via the platform path separator,
 files are loaded left-to-right and later files override earlier file entries.
+Directory entries are also supported and expand to top-level `*.json` files in
+sorted order, making layered addon config bundles easier to manage.
 
 Only known routes are accepted to keep routing safe.
 """
@@ -205,6 +208,37 @@ def _load_single_addon_route_config(config_path: str) -> Tuple[Dict[str, Any] | 
     return aliases_payload, priorities_payload, issues, expanded_path
 
 
+def _expand_addon_route_config_paths(raw_paths: Iterable[str]) -> Tuple[List[str], List[Dict[str, Any]]]:
+    """Expand addon config path entries into an ordered list of JSON files.
+
+    File entries are kept as-is. Directory entries expand to top-level `*.json`
+    files in sorted order so addon bundles can be layered without listing every
+    file in the environment variable.
+    """
+    expanded_paths: List[str] = []
+    issues: List[Dict[str, Any]] = []
+
+    for raw_path in raw_paths:
+        expanded_path = str(Path(raw_path).expanduser())
+        path_obj = Path(expanded_path)
+
+        if path_obj.is_dir():
+            json_files = sorted(
+                str(candidate)
+                for candidate in path_obj.iterdir()
+                if candidate.is_file() and candidate.suffix.lower() == ".json"
+            )
+            if json_files:
+                expanded_paths.extend(json_files)
+            else:
+                issues.append(_addon_config_issue("addon_config_dir_empty", path=expanded_path))
+            continue
+
+        expanded_paths.append(expanded_path)
+
+    return expanded_paths, issues
+
+
 def _load_addon_route_config() -> Tuple[str | None, str | None, List[Dict[str, Any]], str | None, List[str]]:
     """Load route overrides from optional addon JSON config file(s).
 
@@ -223,14 +257,13 @@ def _load_addon_route_config() -> Tuple[str | None, str | None, List[Dict[str, A
     if not raw_paths:
         return None, None, [], config_path, []
 
+    expanded_paths, issues = _expand_addon_route_config_paths(raw_paths)
+
     merged_aliases: Dict[str, Any] = {}
     merged_priorities: Dict[str, Any] = {}
-    issues: List[Dict[str, Any]] = []
-    expanded_paths: List[str] = []
 
-    for raw_path in raw_paths:
-        aliases_payload, priorities_payload, file_issues, expanded_path = _load_single_addon_route_config(raw_path)
-        expanded_paths.append(expanded_path)
+    for expanded_path in expanded_paths:
+        aliases_payload, priorities_payload, file_issues, _ = _load_single_addon_route_config(expanded_path)
         issues.extend(file_issues)
 
         if aliases_payload:

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -57,6 +57,14 @@ else:
 
 from src.processing.pdf.document_processor import DocumentProcessor
 from src.agents.multi_agent_research_system import LangGraphResearchSystem
+from src.agents.routing import (
+    active_route_configuration,
+    ROUTE_GRAPH_ANALYSIS,
+    ROUTE_VECTOR_SEARCH,
+    ROUTE_PDF_ANALYSIS,
+    ROUTE_AUTHOR_COLLECTION,
+    DEFAULT_ROUTE,
+)
 
 class BatchUploadTracker:
     """Tracks batch upload progress to enable resuming interrupted uploads."""
@@ -264,6 +272,9 @@ def main():
     progress_parser.add_argument("directory", type=str, help="Path to the directory to check progress for.")
     progress_parser.add_argument("--clear", action="store_true", help="Clear progress for this directory.")
 
+    # Routes command
+    routes_parser = subparsers.add_parser("routes", help="Show active route configuration.")
+
     args = parser.parse_args()
 
     if args.command == "upload":
@@ -278,6 +289,8 @@ def main():
         handle_batch_upload_command(args)
     elif args.command == "progress":
         handle_progress_command(args)
+    elif args.command == "routes":
+        handle_routes_command(args)
     else:
         parser.print_help()
 
@@ -689,6 +702,70 @@ def handle_progress_command(args):
             print(f"{i}. {os.path.basename(pdf_path)}")
     else:
         print("No files pending processing.")
+
+def handle_routes_command(args):
+    """Handle the routes command to display the active routing configuration."""
+    config = active_route_configuration()
+
+    print("\n=== CiteWeave Route Configuration ===\n")
+    print(f"Default route: {config['default_route']}")
+
+    print(f"\nValid routes:")
+    for route in sorted(config["valid_routes"]):
+        marker = " (default)" if route == config["default_route"] else ""
+        print(f"  {route}{marker}")
+
+    # Aliases section
+    if config["aliases"]:
+        print(f"\nRoute aliases ({len(config['aliases'])} active):")
+        for alias, canonical in sorted(config["aliases"].items()):
+            if alias != canonical:
+                print(f"  {alias} → {canonical}")
+
+    # Priority map
+    if config["priority_map"]:
+        print(f"\nPriority → Route mapping:")
+        for priority, route in sorted(config["priority_map"].items()):
+            print(f"  {priority} → {route}")
+
+    # Active overrides
+    if config["alias_overrides"]:
+        print(f"\nAlias overrides ({len(config['alias_overrides'])} active):")
+        for alias, canonical in sorted(config["alias_overrides"].items()):
+            source = "addon" if alias in config.get("addon_alias_overrides", {}) else "env"
+            print(f"  {alias} → {canonical} [{source}]")
+
+    if config["priority_overrides"]:
+        print(f"\nPriority overrides ({len(config['priority_overrides'])} active):")
+        for priority, route in sorted(config["priority_overrides"].items()):
+            source = "addon" if priority in config.get("addon_priority_overrides", {}) else "env"
+            print(f"  {priority} → {route} [{source}]")
+
+    # Ignored overrides
+    if config["ignored_alias_overrides"]:
+        print(f"\nIgnored alias overrides ({len(config['ignored_alias_overrides'])}):")
+        for entry in config["ignored_alias_overrides"]:
+            print(f"  {entry['key']} → {entry['route']}  [{entry['reason']}]")
+
+    if config["ignored_priority_overrides"]:
+        print(f"\nIgnored priority overrides ({len(config['ignored_priority_overrides'])}):")
+        for entry in config["ignored_priority_overrides"]:
+            print(f"  {entry['key']} → {entry['route']}  [{entry['reason']}]")
+
+    # Config sources
+    if config["addon_config_paths"]:
+        print(f"\nAddon config sources ({len(config['addon_config_paths'])}):")
+        for path in config["addon_config_paths"]:
+            print(f"  {path}")
+
+    if config["addon_config_issues"]:
+        print(f"\nAddon config issues ({len(config['addon_config_issues'])}):")
+        for issue in config["addon_config_issues"]:
+            loc = f" ({issue.get('path', '')})" if issue.get("path") else ""
+            detail = f": {issue.get('detail')}" if issue.get("detail") else ""
+            print(f"  {issue['reason']}{loc}{detail}")
+
+    print()
 
 if __name__ == "__main__":
     main() 

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -232,6 +232,11 @@ def main():
     # Query command  
     query_parser = subparsers.add_parser("query", help="Query the argument graph.")
     query_parser.add_argument("question", type=str, help="Question to ask.")
+    query_parser.add_argument(
+        "--confirmation",
+        default="continue",
+        help="User confirmation mode to pass into the research workflow (default: continue)."
+    )
 
     # Chat command
     chat_parser = subparsers.add_parser("chat", help="Start an interactive chat with the multi-agent research system.")
@@ -333,9 +338,18 @@ def handle_upload_command(args):
 
 def handle_query_command(args):
     """Handle the query command."""
-    print(f"Querying: {args.question}")
-    # TODO: Implement query functionality
-    print("Query functionality not yet implemented.")
+    confirmation = getattr(args, "confirmation", "continue") or "continue"
+
+    try:
+        system = LangGraphResearchSystem()
+        print(f"Querying: {args.question}")
+        response = system.research_question(args.question, confirmation)
+        print()
+        print(response)
+    except Exception as e:
+        print(f"Error querying argument graph: {e}")
+        logging.exception("Query command failed")
+        sys.exit(1)
 
 def handle_diagnose_command(args):
     """Handle the diagnose command."""

--- a/src/utils/config_manager.py
+++ b/src/utils/config_manager.py
@@ -21,8 +21,12 @@ class ConfigManager:
     def load_json(self, filename: str) -> Dict[str, Any]:
         """
         Load a JSON configuration file from the config directory.
+        Prefers an ignored local override like `name.local.json` when present.
         """
-        path = os.path.join(self.config_dir, filename)
+        stem, ext = os.path.splitext(filename)
+        local_name = f"{stem}.local{ext}"
+        local_path = os.path.join(self.config_dir, local_name)
+        path = local_path if os.path.exists(local_path) else os.path.join(self.config_dir, filename)
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
 

--- a/tests/test_cli_query_command.py
+++ b/tests/test_cli_query_command.py
@@ -1,0 +1,86 @@
+import io
+import sys
+import types
+import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _install_cli_stubs():
+    dotenv_module = types.ModuleType("dotenv")
+    dotenv_module.load_dotenv = lambda: None
+    sys.modules.setdefault("dotenv", dotenv_module)
+
+    prompt_toolkit_module = types.ModuleType("prompt_toolkit")
+    prompt_toolkit_module.prompt = lambda *args, **kwargs: ""
+    sys.modules.setdefault("prompt_toolkit", prompt_toolkit_module)
+
+    doc_processor_module = types.ModuleType("src.processing.pdf.document_processor")
+    doc_processor_module.DocumentProcessor = object
+    sys.modules.setdefault("src.processing.pdf.document_processor", doc_processor_module)
+
+    research_module = types.ModuleType("src.agents.multi_agent_research_system")
+    research_module.LangGraphResearchSystem = object
+    sys.modules.setdefault("src.agents.multi_agent_research_system", research_module)
+
+
+_install_cli_stubs()
+
+from src.core import cli  # noqa: E402
+
+
+class QueryCommandTests(unittest.TestCase):
+    def test_handle_query_command_runs_research_workflow(self):
+        args = Namespace(question="What does CiteWeave know about platform ecosystems?", confirmation="expand")
+
+        fake_system = unittest.mock.Mock()
+        fake_system.research_question.return_value = "Structured answer"
+
+        stdout = io.StringIO()
+        with patch.object(cli, "LangGraphResearchSystem", return_value=fake_system):
+            with redirect_stdout(stdout):
+                cli.handle_query_command(args)
+
+        fake_system.research_question.assert_called_once_with(
+            "What does CiteWeave know about platform ecosystems?",
+            "expand",
+        )
+        output = stdout.getvalue()
+        self.assertIn("Querying: What does CiteWeave know about platform ecosystems?", output)
+        self.assertIn("Structured answer", output)
+
+    def test_handle_query_command_defaults_confirmation_to_continue(self):
+        args = Namespace(question="Summarize ambidexterity research")
+
+        fake_system = unittest.mock.Mock()
+        fake_system.research_question.return_value = "Summary"
+
+        with patch.object(cli, "LangGraphResearchSystem", return_value=fake_system):
+            with redirect_stdout(io.StringIO()):
+                cli.handle_query_command(args)
+
+        fake_system.research_question.assert_called_once_with(
+            "Summarize ambidexterity research",
+            "continue",
+        )
+
+    def test_handle_query_command_exits_on_failure(self):
+        args = Namespace(question="broken query", confirmation="continue")
+
+        stdout = io.StringIO()
+        with patch.object(cli, "LangGraphResearchSystem", side_effect=RuntimeError("model unavailable")):
+            with self.assertRaises(SystemExit) as exc:
+                with redirect_stdout(stdout):
+                    cli.handle_query_command(args)
+
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("Error querying argument graph: model unavailable", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_db_agent_content_search.py
+++ b/tests/test_query_db_agent_content_search.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.agents.query_db_agent import QueryDBAgent
+
+
+class QueryDBAgentContentSearchTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = QueryDBAgent.__new__(QueryDBAgent)
+
+    def test_extract_search_candidates_handles_single_and_multiple_match_shapes(self):
+        single = {
+            "status": "single_match",
+            "paper_info": {"paper_id": "p1", "title": "Paper One"},
+        }
+        multiple = {
+            "status": "multiple_matches",
+            "candidates": [
+                {"paper_id": "p1", "title": "Paper One"},
+                {"paper_id": "p2", "title": "Paper Two"},
+            ],
+        }
+
+        self.assertEqual(
+            self.agent._extract_search_candidates(single),
+            [{"paper_id": "p1", "title": "Paper One"}],
+        )
+        self.assertEqual(
+            self.agent._extract_search_candidates(multiple),
+            [
+                {"paper_id": "p1", "title": "Paper One"},
+                {"paper_id": "p2", "title": "Paper Two"},
+            ],
+        )
+        self.assertEqual(self.agent._extract_search_candidates({"status": "no_match"}), [])
+
+    def test_query_pdf_by_title_and_content_uses_single_match_result_schema(self):
+        self.agent.get_papers_id_by_title = lambda title: {
+            "status": "single_match",
+            "paper_info": {"paper_id": "paper-1", "title": title},
+        }
+        self.agent.query_pdf_content = lambda paper_id, query: {
+            "found": True,
+            "paper_id": paper_id,
+            "query": query,
+            "total_matches": 2,
+            "data": [{"section_title": "Intro", "matches": [{"context": "x"}]}],
+        }
+
+        result = self.agent.query_pdf_by_title_and_content("Test Paper", "main argument")
+
+        self.assertTrue(result["found"])
+        self.assertEqual(result["papers_found"], 1)
+        self.assertEqual(result["papers_with_content"], 1)
+        self.assertEqual(result["data"][0]["paper_metadata"]["paper_id"], "paper-1")
+
+    def test_query_pdf_by_author_and_content_uses_multiple_match_result_schema(self):
+        self.agent.get_papers_id_by_author = lambda author: {
+            "status": "multiple_matches",
+            "candidates": [
+                {"paper_id": "paper-1", "title": "Paper One"},
+                {"paper_id": "paper-2", "title": "Paper Two"},
+            ],
+        }
+        self.agent.query_pdf_content = lambda paper_id, query: {
+            "found": paper_id == "paper-2",
+            "paper_id": paper_id,
+            "query": query,
+            "total_matches": 1 if paper_id == "paper-2" else 0,
+            "data": [],
+        }
+
+        result = self.agent.query_pdf_by_author_and_content("Porter", "competitive advantage")
+
+        self.assertTrue(result["found"])
+        self.assertEqual(result["papers_found"], 2)
+        self.assertEqual(result["papers_with_content"], 1)
+        self.assertEqual(result["data"][0]["paper_metadata"]["paper_id"], "paper-2")
+
+    def test_get_full_pdf_content_accepts_alternative_section_keys(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paper_dir = Path(tmpdir) / "paper-1"
+            paper_dir.mkdir(parents=True)
+            (paper_dir / "processed_document.json").write_text(
+                json.dumps(
+                    {
+                        "metadata": {"title": "Test Paper", "authors": ["A. Author"]},
+                        "sections": [
+                            {
+                                "index": 1,
+                                "title": "Abstract",
+                                "type": "abstract",
+                                "text": "This paper argues that network defenses should adapt.",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.agent.papers_dir = tmpdir
+            result = self.agent.get_full_pdf_content("paper-1")
+
+        self.assertTrue(result["found"])
+        self.assertEqual(result["sections_count"], 1)
+        self.assertIn("## Abstract", result["full_text"])
+        self.assertGreater(result["total_word_count"], 0)
+        self.assertEqual(result["section_summaries"][0]["section_type"], "abstract")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recent_paper_argument_smoke.py
+++ b/tests/test_recent_paper_argument_smoke.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.agents.multi_agent_research_system import LangGraphResearchSystem
+
+TEST_TITLES = [
+    "Network Defense: Pruning, Grafting, and Closing to Prevent Leakage of Strategic Knowledge to Rivals",
+    "Stakeholder Relationships and Social Welfare: A Behavioral Theory of Contributions to Joint Value Creation",
+    "Using the SHAPLEY value approach to variance decomposition in strategy research: Diversification, internationalization, and corporate group effects on affiliate profitability",
+]
+
+FAIL_PHRASES = [
+    "no detailed content",
+    "not provided in the sampled content",
+    "no specific content",
+    "not detailed in the available content",
+]
+
+
+def run_test():
+    system = LangGraphResearchSystem(config_path='config')
+    results = []
+
+    for title in TEST_TITLES:
+        question = f'What is the main argument of the paper titled "{title}"?'
+        step1 = system.interactive_research_chat(question)
+        step2 = system.interactive_research_chat(
+            question,
+            menu_choice='1',
+            collected_data=step1['collected_data'],
+        )
+        answer = step2['text']
+        lowered = answer.lower()
+        passed = (
+            len(answer) > 500
+            and all(phrase not in lowered for phrase in FAIL_PHRASES)
+            and ("argument" in lowered or "authors argue" in lowered or "the paper" in lowered)
+        )
+        results.append({
+            'title': title,
+            'passed': passed,
+            'answer_preview': answer[:1500],
+        })
+
+    report = {
+        'passed': all(r['passed'] for r in results),
+        'results': results,
+    }
+    report_path = Path('tests/_artifacts/recent_paper_argument_smoke.json')
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding='utf-8')
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if not report['passed']:
+        raise SystemExit(1)
+
+
+if __name__ == '__main__':
+    run_test()

--- a/tests/test_repo_privacy_audit.py
+++ b/tests/test_repo_privacy_audit.py
@@ -1,0 +1,69 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(ROOT))
+from scripts.repo_privacy_audit import emit_report, scan_repo  # noqa: E402
+
+
+class RepoPrivacyAuditTests(unittest.TestCase):
+    def make_repo(self, files: dict[str, str], tracked: list[str] | None = None) -> tuple[Path, list[str]]:
+        tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tempdir.cleanup)
+        repo = Path(tempdir.name) / 'repo'
+        repo.mkdir()
+        subprocess.run(['git', 'init'], cwd=repo, check=True, capture_output=True)
+
+        tracked = tracked or list(files)
+        for rel, content in files.items():
+            path = repo / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding='utf-8')
+
+        if tracked:
+            subprocess.run(['git', 'add', *tracked], cwd=repo, check=True, capture_output=True)
+
+        return repo, tracked
+
+    def test_scan_repo_flags_absolute_workspace_path(self):
+        leaked_path = '/'.join(['', 'home', 'tiresias']) + '/' + '.openclaw' + '/workspace/projects/CiteWeave'
+        repo, tracked = self.make_repo(
+            {'README.md': f'local path: {leaked_path}'},
+        )
+
+        violations = scan_repo(repo, tracked)
+
+        self.assertEqual(violations, [('README.md', 'absolute local workspace path')])
+
+    def test_scan_repo_flags_tracked_local_override_file(self):
+        repo, tracked = self.make_repo(
+            {'config/neo4j_config.local.json': '{"password": "CHANGE_ME_LOCAL_ONLY"}'},
+        )
+
+        violations = scan_repo(repo, tracked)
+
+        self.assertEqual(violations, [('config/neo4j_config.local.json', 'tracked local override config')])
+
+    def test_scan_repo_ignores_untracked_local_override_file(self):
+        repo, tracked = self.make_repo(
+            {
+                'config/neo4j_config.json': '{"password": "CHANGE_ME_LOCAL_ONLY"}',
+                'config/neo4j_config.local.json': '{"password": "' + '1234' + '5678' + '"}',
+            },
+            tracked=['config/neo4j_config.json'],
+        )
+
+        violations = scan_repo(repo, tracked)
+
+        self.assertEqual(violations, [])
+
+    def test_emit_report_returns_success_for_clean_repo(self):
+        self.assertEqual(emit_report([]), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_repo_privacy_audit.py
+++ b/tests/test_repo_privacy_audit.py
@@ -48,6 +48,15 @@ class RepoPrivacyAuditTests(unittest.TestCase):
 
         self.assertEqual(violations, [('config/neo4j_config.local.json', 'tracked local override config')])
 
+    def test_scan_repo_flags_tracked_local_yaml_override_file(self):
+        repo, tracked = self.make_repo(
+            {'config/runtime.local.yaml': 'model: local-only'},
+        )
+
+        violations = scan_repo(repo, tracked)
+
+        self.assertEqual(violations, [('config/runtime.local.yaml', 'tracked local override config')])
+
     def test_scan_repo_ignores_untracked_local_override_file(self):
         repo, tracked = self.make_repo(
             {
@@ -60,6 +69,34 @@ class RepoPrivacyAuditTests(unittest.TestCase):
         violations = scan_repo(repo, tracked)
 
         self.assertEqual(violations, [])
+
+    def test_scan_repo_flags_github_token(self):
+        repo, tracked = self.make_repo(
+            {'docs/example.md': 'token=ghp_' + 'A' * 36},
+        )
+
+        violations = scan_repo(repo, tracked)
+
+        self.assertEqual(violations, [('docs/example.md', 'GitHub personal access token')])
+
+    def test_scan_repo_flags_openai_key_like_secret(self):
+        repo, tracked = self.make_repo(
+            {'docs/example.md': 'OPENAI_API_KEY=sk-proj-' + 'abc123XYZ_' * 3},
+        )
+
+        violations = scan_repo(repo, tracked)
+
+        self.assertEqual(violations, [('docs/example.md', 'OpenAI API key-like secret')])
+
+    def test_scan_repo_flags_private_key_material(self):
+        private_key_block = '-----BEGIN ' + 'OPENSSH PRIVATE KEY-----\npretend\n-----END OPENSSH PRIVATE KEY-----'
+        repo, tracked = self.make_repo(
+            {'config/keys.txt': private_key_block},
+        )
+
+        violations = scan_repo(repo, tracked)
+
+        self.assertEqual(violations, [('config/keys.txt', 'private key material')])
 
     def test_emit_report_returns_success_for_clean_repo(self):
         self.assertEqual(emit_report([]), 0)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -507,3 +507,80 @@ def test_active_route_configuration_reports_unknown_addon_config_keys():
         else:
             os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = original_path
         Path(tmp_path).unlink(missing_ok=True)
+
+
+def test_active_route_configuration_expands_directory_entries_in_load_order():
+    routing = _load_routing_module()
+    original_path = os.environ.get("CITEWEAVE_ROUTE_ADDON_CONFIG")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_path = Path(tmp_dir) / "00-base.json"
+        overlay_path = Path(tmp_dir) / "10-overlay.json"
+        ignored_path = Path(tmp_dir) / "README.txt"
+
+        base_path.write_text(
+            json.dumps(
+                {
+                    "aliases": {"semantic": "vector"},
+                    "priority_overrides": {"author_index": "graph"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        overlay_path.write_text(
+            json.dumps(
+                {
+                    "aliases": {"semantic": "pdf", "citation_map": "graph"},
+                    "priority_overrides": {"author_index": "semantic"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        ignored_path.write_text("not json", encoding="utf-8")
+
+        try:
+            os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = tmp_dir
+
+            config = routing.active_route_configuration()
+
+            assert config["addon_config_path"] == tmp_dir
+            assert config["addon_config_paths"] == [str(base_path), str(overlay_path)]
+            assert config["addon_config_issues"] == []
+            assert config["addon_alias_overrides"] == {
+                "semantic": routing.ROUTE_PDF_ANALYSIS,
+                "citation_map": routing.ROUTE_GRAPH_ANALYSIS,
+            }
+            assert config["addon_priority_overrides"] == {
+                "author_index": routing.ROUTE_PDF_ANALYSIS,
+            }
+            assert routing.resolve_route("semantic") == routing.ROUTE_PDF_ANALYSIS
+            assert routing.route_for_priority("author_index") == routing.ROUTE_PDF_ANALYSIS
+        finally:
+            if original_path is None:
+                os.environ.pop("CITEWEAVE_ROUTE_ADDON_CONFIG", None)
+            else:
+                os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = original_path
+
+
+def test_active_route_configuration_reports_empty_addon_config_directory():
+    routing = _load_routing_module()
+    original_path = os.environ.get("CITEWEAVE_ROUTE_ADDON_CONFIG")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        try:
+            os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = tmp_dir
+
+            config = routing.active_route_configuration()
+
+            assert config["addon_config_paths"] == []
+            assert config["addon_config_issues"] == [
+                {
+                    "reason": "addon_config_dir_empty",
+                    "path": tmp_dir,
+                }
+            ]
+        finally:
+            if original_path is None:
+                os.environ.pop("CITEWEAVE_ROUTE_ADDON_CONFIG", None)
+            else:
+                os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = original_path

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -584,3 +584,41 @@ def test_active_route_configuration_reports_empty_addon_config_directory():
                 os.environ.pop("CITEWEAVE_ROUTE_ADDON_CONFIG", None)
             else:
                 os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = original_path
+
+
+def test_active_route_configuration_ignores_subdirectories_in_addon_config_path():
+    """Subdirectories within an addon config directory path should be silently skipped."""
+    routing = _load_routing_module()
+    original_path = os.environ.get("CITEWEAVE_ROUTE_ADDON_CONFIG")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        json_path = Path(tmp_dir) / "00-valid.json"
+        json_path.write_text(
+            json.dumps({"aliases": {"semantic": "vector"}}),
+            encoding="utf-8",
+        )
+        # Nested subdirectory should be ignored (not walked recursively)
+        nested_dir = Path(tmp_dir) / "subdir"
+        nested_dir.mkdir()
+        (nested_dir / "nested.json").write_text(
+            json.dumps({"aliases": {"nested_alias": "author_collection"}}),
+            encoding="utf-8",
+        )
+
+        try:
+            os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = tmp_dir
+
+            config = routing.active_route_configuration()
+
+            # Only the top-level JSON should be picked up; nested files ignored
+            assert config["addon_config_paths"] == [str(json_path)]
+            assert config["addon_config_issues"] == []
+            assert config["addon_alias_overrides"] == {"semantic": routing.ROUTE_VECTOR_SEARCH}
+            # Nested alias should NOT appear
+            assert "nested_alias" not in config["addon_alias_overrides"]
+            assert routing.resolve_route("nested_alias") is None
+        finally:
+            if original_path is None:
+                os.environ.pop("CITEWEAVE_ROUTE_ADDON_CONFIG", None)
+            else:
+                os.environ["CITEWEAVE_ROUTE_ADDON_CONFIG"] = original_path


### PR DESCRIPTION
## Summary

This PR adds a `routes` CLI command that exposes the active routing configuration (valid routes, aliases, priority mappings, active overrides, and addon config sources), alongside the existing `feat/route-addon-config-directory-support` feature.

## Changes

- **New**: `citeweave routes` command showing:
  - Valid routes and the default route
  - Route aliases and priority → route mappings
  - Active alias/priority overrides (with source: addon vs env)
  - Ignored override entries with reasons
  - Addon config file sources and any loading issues

## Previous commits in this branch

- `feat(routing): support addon config directories` — directory expansion for `CITEWEAVE_ROUTE_ADDON_CONFIG`
- `feat(cli): implement query command workflow` — `citeweave query <question>`
- `fix(search): use full paper content for argument queries`
- `chore(privacy): expand secret leak detection`
- `chore: harden PR workflow and local-config privacy`

## Testing

- Routing unit tests: 5/5 pass
- Privacy audit: PASS
- CLI syntax: OK