### PR TITLE
feat(cli): enrich progress summaries and query diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,7 +235,8 @@ training_args.bin
 data/*
 !data/README.md
 
-# Local test PDFs should stay out of git
+# Local test PDFs should stay out of git.
+# Canonical ignore rule is `test_files/*` while keeping the tracked README.
 test_files/*
 !test_files/README.md
 

--- a/Development_Logs.md
+++ b/Development_Logs.md
@@ -18,6 +18,10 @@ This document tracks the development progress of all major modules in the projec
 
 ## Recent Development Progress
 
+## **2026-04-05**
+- **batch progress ETA & throughput diagnostics**: extended batch upload tracking to record per-file processing duration, surface average completed time per file, and estimate remaining wall time in `progress` output/JSON so long-running PDF ingests are easier to monitor and resume.
+- **test coverage**: added regression coverage for duration persistence, progress ETA calculation, and enriched sequential batch tracker payloads.
+
 ## **2025-07-22**
 - **information-collection summary**: Fix the infomration collection summary issue.
 - **ai_evaluate_sufficiency-agent**: A new agent that is responsible for judging if the information gathered is sufficient to answer the user's question.

--- a/Development_Logs.md
+++ b/Development_Logs.md
@@ -18,6 +18,10 @@ This document tracks the development progress of all major modules in the projec
 
 ## Recent Development Progress
 
+## **2026-04-09**
+- **query history source diagnostics**: extended query telemetry with entrypoint source labels (`cli.query`, `openclaw.facade.query`, etc.) and added CLI `query-history --source` filtering plus source/confirmation breakdowns so validation traffic can be separated from real usage windows during daily iteration.
+- **test coverage**: added regression coverage for source-aware query history summaries, CLI filtering, and OpenClaw facade query tagging.
+
 ## **2026-04-08**
 - **repo hygiene clarification**: documented the canonical `.gitignore` rule for `test_files/*` so consistency checks do not keep inventing punctuation as a feature.
 - **query history time-window inspection**: extended `query-history` with `--since-hours` and timestamp/relative-age output so recent telemetry windows can be reviewed directly from the CLI during daily iteration.

--- a/Development_Logs.md
+++ b/Development_Logs.md
@@ -18,6 +18,11 @@ This document tracks the development progress of all major modules in the projec
 
 ## Recent Development Progress
 
+## **2026-04-08**
+- **repo hygiene clarification**: documented the canonical `.gitignore` rule for `test_files/*` so consistency checks do not keep inventing punctuation as a feature.
+- **query history time-window inspection**: extended `query-history` with `--since-hours` and timestamp/relative-age output so recent telemetry windows can be reviewed directly from the CLI during daily iteration.
+- **test coverage**: added regression coverage for time-window filtering and query-history CLI output.
+
 ## **2026-04-06**
 - **query history inspection**: added a first-class `query-history` CLI command and kernel snapshot so recent query telemetry can be reviewed without reading raw JSONL by hand; includes recent entries, success/error counts, and latency summary for daily UX iteration.
 - **test coverage**: added regression tests for query-history summaries, corrupt-row handling, and actionable CLI output.

--- a/Development_Logs.md
+++ b/Development_Logs.md
@@ -18,6 +18,10 @@ This document tracks the development progress of all major modules in the projec
 
 ## Recent Development Progress
 
+## **2026-04-06**
+- **query history inspection**: added a first-class `query-history` CLI command and kernel snapshot so recent query telemetry can be reviewed without reading raw JSONL by hand; includes recent entries, success/error counts, and latency summary for daily UX iteration.
+- **test coverage**: added regression tests for query-history summaries, corrupt-row handling, and actionable CLI output.
+
 ## **2026-04-05**
 - **batch progress ETA & throughput diagnostics**: extended batch upload tracking to record per-file processing duration, surface average completed time per file, and estimate remaining wall time in `progress` output/JSON so long-running PDF ingests are easier to monitor and resume.
 - **test coverage**: added regression coverage for duration persistence, progress ETA calculation, and enriched sequential batch tracker payloads.

--- a/README.md
+++ b/README.md
@@ -209,11 +209,14 @@ other docs.
 ### `query-history`
 
 Inspect recent query telemetry from the local JSONL history log. This is useful
-for spotting slow or failed research runs without opening the raw log file.
+for spotting slow or failed research runs without opening the raw log file, and
+for separating CLI traffic from OpenClaw-driven queries when you need to audit
+how the system is actually being used.
 
 ```bash
 .venv/bin/python -m src.core.cli query-history
 .venv/bin/python -m src.core.cli query-history --limit 20
+.venv/bin/python -m src.core.cli query-history --source cli.query --since-hours 24
 .venv/bin/python -m src.core.cli query-history --json
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,12 +143,17 @@ Upload and process all PDFs in a directory.
 
 ### `progress <directory>`
 
-Inspect or clear batch-upload progress tracking.
+Inspect or clear batch-upload progress tracking. The report distinguishes between retryable failed files and PDFs that have not been attempted yet, so resume decisions are less guesswork and more engineering.
 
 ```bash
 .venv/bin/python -m src.core.cli progress path/to/papers/
 .venv/bin/python -m src.core.cli progress path/to/papers/ --clear
 ```
+
+The text output now breaks remaining work into:
+- **Retryable failed files**: attempted previously, failed, and will be retried by `batch-upload --resume`
+- **Not started yet**: discovered PDFs with no tracker entry yet
+- **Pending files**: the union of both groups above
 
 ### `chat`
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ and addon/env overrides.
 
 ### `health`
 
-Inspect machine-readable environment and service health, including local
-backend probes and configuration file presence.
+Inspect environment and service health. The human-readable output now leads
+with an overall verdict and recommended next actions; use `--json` when you
+want the raw machine-readable snapshot.
 
 ```bash
 .venv/bin/python -m src.core.cli health

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ and addon/env overrides.
 
 ## Part 2 — Integrate CiteWeave with OpenClaw
 
+For the architectural contract behind this split, see:
+`docs/KERNEL_AND_OPENCLAW.md`
+
 ### What changes in OpenClaw mode
 
 OpenClaw does not replace CiteWeave's storage or parsing stack. It only becomes

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Current CLI commands available on this branch:
 - `chat`
 - `query`
 - `routes`
+- `health`
+- `bootstrap-plan`
 
 ### Local CLI mode (no OpenClaw needed)
 
@@ -69,6 +71,8 @@ Then run CiteWeave through the project virtualenv:
 .venv/bin/python -m src.core.cli batch-upload ./papers --resume
 .venv/bin/python -m src.core.cli query "Which papers discuss X?"
 .venv/bin/python -m src.core.cli routes
+.venv/bin/python -m src.core.cli health
+.venv/bin/python -m src.core.cli bootstrap-plan
 .venv/bin/python -m src.core.cli chat
 ```
 
@@ -172,6 +176,26 @@ and addon/env overrides.
 
 ```bash
 .venv/bin/python -m src.core.cli routes
+```
+
+### `health`
+
+Inspect machine-readable environment and service health, including local
+backend probes and configuration file presence.
+
+```bash
+.venv/bin/python -m src.core.cli health
+.venv/bin/python -m src.core.cli health --json
+```
+
+### `bootstrap-plan`
+
+Print the recommended local CLI and OpenClaw bootstrap steps without scraping
+other docs.
+
+```bash
+.venv/bin/python -m src.core.cli bootstrap-plan
+.venv/bin/python -m src.core.cli bootstrap-plan --json
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Current CLI commands available on this branch:
 - `routes`
 - `health`
 - `bootstrap-plan`
+- `query-history`
 
 ### Local CLI mode (no OpenClaw needed)
 
@@ -73,6 +74,7 @@ Then run CiteWeave through the project virtualenv:
 .venv/bin/python -m src.core.cli routes
 .venv/bin/python -m src.core.cli health
 .venv/bin/python -m src.core.cli bootstrap-plan
+.venv/bin/python -m src.core.cli query-history --limit 20
 .venv/bin/python -m src.core.cli chat
 ```
 
@@ -202,6 +204,17 @@ other docs.
 ```bash
 .venv/bin/python -m src.core.cli bootstrap-plan
 .venv/bin/python -m src.core.cli bootstrap-plan --json
+```
+
+### `query-history`
+
+Inspect recent query telemetry from the local JSONL history log. This is useful
+for spotting slow or failed research runs without opening the raw log file.
+
+```bash
+.venv/bin/python -m src.core.cli query-history
+.venv/bin/python -m src.core.cli query-history --limit 20
+.venv/bin/python -m src.core.cli query-history --json
 ```
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -162,6 +162,9 @@ bash scripts/deployment_check.sh
 
 ## 第二部分：将 CiteWeave 接入 OpenClaw
 
+关于这种分层方式背后的架构约定，可继续看：
+`docs/KERNEL_AND_OPENCLAW.md`
+
 ### OpenClaw 模式到底改变了什么
 
 OpenClaw 不会替代 CiteWeave 的存储或解析层，它只是接管 CiteWeave 的

--- a/docs/KERNEL_AND_OPENCLAW.md
+++ b/docs/KERNEL_AND_OPENCLAW.md
@@ -66,8 +66,12 @@ Current facade methods:
 - `upload_pdf(pdf_path)`
 - `diagnose_pdf(pdf_path)`
 - `query(question, confirmation='continue')`
+- `chat_turn(user_input, history=None, menu_choice=None, collected_data=None)`
 - `routes()`
 - `progress(directory, clear=False)`
+- `batch_upload(directory, resume=True, force_restart=False, clear_progress=False)`
+- `health()`
+- `bootstrap_plan()`
 
 ## Recommended future OpenClaw Skill design
 

--- a/docs/KERNEL_AND_OPENCLAW.md
+++ b/docs/KERNEL_AND_OPENCLAW.md
@@ -1,0 +1,106 @@
+# CiteWeave as a Kernel + Adapter System
+
+This document defines the intended architecture for integrating CiteWeave with
+OpenClaw without coupling the research kernel to any one frontend.
+
+## Core idea
+
+Treat **CiteWeave as a kernel**:
+
+- PDF ingestion
+- citation graph maintenance
+- vector search
+- research workflow orchestration
+- route diagnostics
+- persistence in Neo4j / Qdrant / derived files
+
+Treat **CLI / OpenClaw Skill / future HTTP API** as adapters.
+
+## Layers
+
+### 1. Kernel layer
+
+Location:
+
+- `src/kernel/service.py`
+- `src/kernel/batch_tracker.py`
+
+Responsibilities:
+
+- expose stable application operations:
+  - `upload_document(pdf_path)`
+  - `diagnose_document(pdf_path)`
+  - `query(question, confirmation='continue')`
+  - `routes_snapshot()`
+  - `progress_summary(directory, clear=False)`
+- compose heavy internals (`DocumentProcessor`, `LangGraphResearchSystem`)
+- remain adapter-agnostic
+
+### 2. CLI adapter
+
+Location:
+
+- `src/core/cli.py`
+
+Responsibilities:
+
+- parse argv
+- print human-readable output
+- keep interactive `chat` loop in terminal form
+- call `CiteWeaveKernel` instead of directly wiring internals everywhere
+
+### 3. OpenClaw adapter
+
+Location:
+
+- `src/adapters/openclaw_facade.py`
+
+Responsibilities:
+
+- expose serializable methods suitable for a future Skill
+- avoid terminal scraping
+- return structured dictionaries for agent/tool handling
+
+Current facade methods:
+
+- `upload_pdf(pdf_path)`
+- `diagnose_pdf(pdf_path)`
+- `query(question, confirmation='continue')`
+- `routes()`
+- `progress(directory, clear=False)`
+
+## Recommended future OpenClaw Skill design
+
+The future skill should **not** reimplement CiteWeave logic.
+Instead it should:
+
+1. ensure CiteWeave is bootstrapped
+2. check `docker-compose` services and OpenClaw gateway health
+3. call the OpenClaw facade (or a future local HTTP API)
+4. format results back to the user
+
+### Suggested Skill workflow
+
+1. `bootstrap_openclaw.sh` if missing / first run
+2. call `OpenClawCiteWeaveFacade.routes()` for environment diagnostics
+3. call `upload_pdf()` / `query()` / `diagnose_pdf()` as needed
+4. optionally maintain session memory at the OpenClaw layer, not in the kernel
+
+## Why this split matters
+
+Without this split, three things get tangled together:
+
+- research engine logic
+- user interface concerns
+- OpenClaw-specific orchestration
+
+That makes docs, testing, and future APIs drift apart. The kernel/adapter split
+keeps the database-backed research engine stable while allowing multiple entry
+points to evolve independently.
+
+## What remains future work
+
+- add a local HTTP adapter (likely FastAPI)
+- make batch upload callable through the OpenClaw facade
+- add machine-readable health/status commands beyond current CLI output
+- add integration tests that exercise kernel methods directly

--- a/docs/KERNEL_AND_OPENCLAW.md
+++ b/docs/KERNEL_AND_OPENCLAW.md
@@ -106,5 +106,5 @@ points to evolve independently.
 
 - add a local HTTP adapter (likely FastAPI)
 - make batch upload callable through the OpenClaw facade
-- add machine-readable health/status commands beyond current CLI output
+- expand machine-readable health/status coverage beyond the current CLI `health` / `bootstrap-plan` commands
 - add integration tests that exercise kernel methods directly

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,8 +1,8 @@
-# This file makes 'src' a Python package for Poetry and Python imports.
+"""Top-level package for CiteWeave.
 
-# Main modules for the argument graph project
-from src.processing.pdf.document_processor import DocumentProcessor
-from src.processing.pdf.pdf_processor import PDFProcessor  
-from src.processing.citation_parser import CitationParser
+Keep package import side effects minimal.
+Heavy runtime objects (PDF processors, agent systems) should be imported from
+specific modules or through the kernel/adapters layer, not from `src` itself.
+"""
 
-__all__ = ['DocumentProcessor', 'PDFProcessor', 'CitationParser'] 
+__all__ = []

--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,9 @@
+"""Adapter layer for CiteWeave.
+
+Adapters translate external entrypoints into calls on the kernel layer.
+Examples: CLI, OpenClaw Skill, future HTTP API.
+"""
+
+from .openclaw_facade import OpenClawCiteWeaveFacade
+
+__all__ = ["OpenClawCiteWeaveFacade"]

--- a/src/adapters/openclaw_facade.py
+++ b/src/adapters/openclaw_facade.py
@@ -1,0 +1,45 @@
+"""OpenClaw-facing adapter facade for CiteWeave.
+
+This module is intentionally thin: OpenClaw should treat CiteWeave as a kernel
+and call explicit, serializable methods here (or a future HTTP layer), instead
+of scraping terminal output.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from src.kernel import CiteWeaveKernel
+
+
+class OpenClawCiteWeaveFacade:
+    """Stable facade intended for a future OpenClaw Skill adapter."""
+
+    def __init__(self, kernel: CiteWeaveKernel | None = None):
+        self.kernel = kernel or CiteWeaveKernel()
+
+    def upload_pdf(self, pdf_path: str) -> Dict[str, Any]:
+        result = self.kernel.upload_document(pdf_path)
+        stats = result.get("processing_stats", {})
+        return {
+            "paper_id": result.get("paper_id"),
+            "stats": stats,
+            "sentences_with_citations": result.get("sentences_with_citations", []),
+        }
+
+    def diagnose_pdf(self, pdf_path: str) -> Dict[str, Any]:
+        return self.kernel.diagnose_document(pdf_path)
+
+    def query(self, question: str, confirmation: str = "continue") -> Dict[str, Any]:
+        answer = self.kernel.query(question, confirmation)
+        return {
+            "question": question,
+            "confirmation": confirmation,
+            "answer": answer,
+        }
+
+    def routes(self) -> Dict[str, Any]:
+        return self.kernel.routes_snapshot()
+
+    def progress(self, directory: str, clear: bool = False) -> Dict[str, Any]:
+        return self.kernel.progress_summary(directory, clear=clear)

--- a/src/adapters/openclaw_facade.py
+++ b/src/adapters/openclaw_facade.py
@@ -7,13 +7,17 @@ of scraping terminal output.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from src.kernel import CiteWeaveKernel
 
 
 class OpenClawCiteWeaveFacade:
-    """Stable facade intended for a future OpenClaw Skill adapter."""
+    """Stable facade intended for a future OpenClaw Skill adapter.
+
+    Return values are structured dictionaries so OpenClaw skills or tools can
+    consume them without scraping terminal output.
+    """
 
     def __init__(self, kernel: CiteWeaveKernel | None = None):
         self.kernel = kernel or CiteWeaveKernel()
@@ -43,3 +47,43 @@ class OpenClawCiteWeaveFacade:
 
     def progress(self, directory: str, clear: bool = False) -> Dict[str, Any]:
         return self.kernel.progress_summary(directory, clear=clear)
+
+
+    def chat_turn(
+        self,
+        user_input: str,
+        history: Optional[list] = None,
+        menu_choice: Optional[str] = None,
+        collected_data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        result = self.kernel.chat_turn(
+            user_input,
+            history=history,
+            menu_choice=menu_choice,
+            collected_data=collected_data,
+        )
+        return {
+            "input": user_input,
+            "menu_choice": menu_choice,
+            **result,
+        }
+
+    def batch_upload(
+        self,
+        directory: str,
+        resume: bool = True,
+        force_restart: bool = False,
+        clear_progress: bool = False,
+    ) -> Dict[str, Any]:
+        return self.kernel.batch_upload(
+            directory,
+            resume=resume,
+            force_restart=force_restart,
+            clear_progress=clear_progress,
+        )
+
+    def health(self) -> Dict[str, Any]:
+        return self.kernel.health_snapshot()
+
+    def bootstrap_plan(self) -> Dict[str, Any]:
+        return self.kernel.bootstrap_plan()

--- a/src/adapters/openclaw_facade.py
+++ b/src/adapters/openclaw_facade.py
@@ -35,7 +35,7 @@ class OpenClawCiteWeaveFacade:
         return self.kernel.diagnose_document(pdf_path)
 
     def query(self, question: str, confirmation: str = "continue") -> Dict[str, Any]:
-        answer = self.kernel.query(question, confirmation)
+        answer = self.kernel.query(question, confirmation, source="openclaw.facade.query")
         return {
             "question": question,
             "confirmation": confirmation,

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -166,6 +166,7 @@ def main():
     query_history_parser = subparsers.add_parser("query-history", help="Inspect recent query telemetry from the local JSONL history log.")
     query_history_parser.add_argument("--limit", type=int, default=10, help="How many recent query records to include (default: 10).")
     query_history_parser.add_argument("--status", choices=["all", "success", "error", "corrupt"], default="all", help="Filter to a specific query status (default: all).")
+    query_history_parser.add_argument("--source", default="all", help="Filter to a specific query source, such as cli.query or openclaw.facade.query.")
     query_history_parser.add_argument("--since-hours", type=float, default=None, help="Only include query records from the last N hours.")
     query_history_parser.add_argument("--json", action="store_true", help="Print machine-readable query history as JSON.")
 
@@ -253,7 +254,7 @@ def handle_query_command(args):
     try:
         kernel = CiteWeaveKernel()
         print(f"Querying: {args.question}")
-        response = kernel.query(args.question, confirmation)
+        response = kernel.query(args.question, confirmation, source="cli.query")
         print()
         print(response)
     except Exception as e:
@@ -852,6 +853,7 @@ def handle_query_history_command(args):
     snapshot = kernel.query_history_snapshot(
         limit=max(0, getattr(args, "limit", 10)),
         status=getattr(args, "status", "all") or "all",
+        source=getattr(args, "source", "all") or "all",
         since_hours=since_hours,
     )
 
@@ -863,6 +865,7 @@ def handle_query_history_command(args):
     print(f"Log file: {snapshot.get('log_file', '')}")
     print(f"Requested limit: {snapshot.get('requested_limit', 0)}")
     print(f"Status filter: {snapshot.get('status_filter', 'all')}")
+    print(f"Source filter: {snapshot.get('source_filter', 'all')}")
     if snapshot.get("since_hours") is not None:
         print(f"Time window: last {snapshot.get('since_hours')} hours")
     print(f"Entries returned: {snapshot.get('entries_returned', 0)}")
@@ -879,12 +882,26 @@ def handle_query_history_command(args):
 
     latest_status = snapshot.get("latest_status")
     latest_question = snapshot.get("latest_question")
+    latest_source = snapshot.get("latest_source")
     if latest_status or latest_question:
-        print(f"Latest query: {latest_status or 'unknown'} - {latest_question or ''}")
+        source_suffix = f" [{latest_source}]" if latest_source else ""
+        print(f"Latest query: {latest_status or 'unknown'}{source_suffix} - {latest_question or ''}")
 
     latest_error = snapshot.get("latest_error")
     if latest_error:
         print(f"Latest error: {latest_error}")
+
+    source_breakdown = snapshot.get("source_breakdown") or []
+    if source_breakdown:
+        print("Sources:")
+        for item in source_breakdown:
+            print(f"  - {item['source']}: {item['count']}")
+
+    confirmation_breakdown = snapshot.get("confirmation_breakdown") or []
+    if confirmation_breakdown:
+        print("Confirmations:")
+        for item in confirmation_breakdown:
+            print(f"  - {item['confirmation']}: {item['count']}")
 
     entries = snapshot.get("entries", [])
     if not entries:
@@ -897,12 +914,14 @@ def handle_query_history_command(args):
         status = entry.get("status", "unknown")
         duration = entry.get("duration_ms")
         question = entry.get("question") or entry.get("raw_line") or ""
+        source = entry.get("source")
         duration_text = f" ({duration} ms)" if isinstance(duration, int) else ""
+        source_text = f" {{{source}}}" if source else ""
         timestamp_text = _format_query_history_timestamp(entry.get("timestamp"))
         relative_age = _format_relative_age(entry.get("timestamp"))
         when_text = f" at {timestamp_text}" if timestamp_text else ""
         age_text = f" [{relative_age}]" if relative_age else ""
-        print(f"{idx}. [{status}]{duration_text}{when_text}{age_text} {question}")
+        print(f"{idx}. [{status}]{source_text}{duration_text}{when_text}{age_text} {question}")
 
     print()
 

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -56,129 +56,7 @@ else:
         logging.getLogger(noisy_logger).setLevel(logging.WARNING)
 
 from src.processing.pdf.document_processor import DocumentProcessor
-from src.agents.multi_agent_research_system import LangGraphResearchSystem
-from src.agents.routing import active_route_configuration
-
-class BatchUploadTracker:
-    """Tracks batch upload progress to enable resuming interrupted uploads."""
-    
-    def __init__(self, directory, tracker_file=None):
-        self.directory = directory
-        if tracker_file is None:
-            # Create tracker file in data folder
-            data_dir = Path("data")
-            data_dir.mkdir(exist_ok=True)
-            self.tracker_file = data_dir / "batch_upload_tracker.json"
-        else:
-            self.tracker_file = Path(tracker_file)
-        
-        self.progress_data = self._load_progress()
-    
-    def _load_progress(self):
-        """Load existing progress from tracker file."""
-        if self.tracker_file.exists():
-            try:
-                with open(self.tracker_file, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                    # Filter to only include entries for current directory
-                    return {k: v for k, v in data.items() if v.get('directory') == self.directory}
-            except (json.JSONDecodeError, IOError) as e:
-                logging.warning(f"Could not load progress tracker: {e}")
-                return {}
-        return {}
-    
-    def _save_progress(self):
-        """Save progress to tracker file."""
-        try:
-            # Load existing data to preserve other directories
-            existing_data = {}
-            if self.tracker_file.exists():
-                try:
-                    with open(self.tracker_file, 'r', encoding='utf-8') as f:
-                        existing_data = json.load(f)
-                except (json.JSONDecodeError, IOError):
-                    existing_data = {}
-            
-            # Update with current directory data
-            existing_data.update(self.progress_data)
-            
-            # Save back to file
-            with open(self.tracker_file, 'w', encoding='utf-8') as f:
-                json.dump(existing_data, f, indent=2, ensure_ascii=False)
-                
-        except IOError as e:
-            logging.error(f"Could not save progress tracker: {e}")
-    
-    def mark_file_completed(self, pdf_path, result):
-        """Mark a file as successfully processed."""
-        self.progress_data[pdf_path] = {
-            'status': 'completed',
-            'directory': self.directory,
-            'paper_id': result.get('paper_id', 'unknown'),
-            'total_sentences': result.get('total_sentences', 0),
-            'total_citations': result.get('total_citations', 0),
-            'completed_at': time.strftime('%Y-%m-%d %H:%M:%S'),
-            'error': None
-        }
-        self._save_progress()
-    
-    def mark_file_failed(self, pdf_path, error):
-        """Mark a file as failed."""
-        self.progress_data[pdf_path] = {
-            'status': 'failed',
-            'directory': self.directory,
-            'paper_id': None,
-            'total_sentences': 0,
-            'total_citations': 0,
-            'completed_at': time.strftime('%Y-%m-%d %H:%M:%S'),
-            'error': str(error)
-        }
-        self._save_progress()
-    
-    def is_file_completed(self, pdf_path):
-        """Check if a file has been successfully processed."""
-        return pdf_path in self.progress_data and self.progress_data[pdf_path]['status'] == 'completed'
-    
-    def is_file_failed(self, pdf_path):
-        """Check if a file has failed processing."""
-        return pdf_path in self.progress_data and self.progress_data[pdf_path]['status'] == 'failed'
-    
-    def get_pending_files(self, all_files, force_restart=False):
-        """Get list of files that need processing."""
-        if force_restart:
-            return all_files
-        
-        pending = []
-        for pdf_path in all_files:
-            if not self.is_file_completed(pdf_path):
-                pending.append(pdf_path)
-        
-        return pending
-    
-    def get_progress_summary(self):
-        """Get summary of current progress."""
-        total = len(self.progress_data)
-        completed = sum(1 for v in self.progress_data.values() if v['status'] == 'completed')
-        failed = sum(1 for v in self.progress_data.values() if v['status'] == 'failed')
-        
-        return {
-            'total_tracked': total,
-            'completed': completed,
-            'failed': failed,
-            'success_rate': (completed / total * 100) if total > 0 else 0
-        }
-    
-    def clear_progress(self, directory=None):
-        """Clear progress for a specific directory or all progress."""
-        if directory:
-            # Remove entries for specific directory
-            self.progress_data = {k: v for k, v in self.progress_data.items() 
-                                if v.get('directory') != directory}
-        else:
-            # Clear all progress
-            self.progress_data = {}
-        
-        self._save_progress()
+from src.kernel import CiteWeaveKernel, BatchUploadTracker
 
 def process_single_pdf_worker(pdf_path, diagnose=False, force=False):
     """
@@ -289,33 +167,30 @@ def main():
         parser.print_help()
 
 def handle_upload_command(args):
-    """Handle the upload command with integrated PDF and citation processing."""
+    """Handle the upload command through the kernel service."""
     try:
-        # Initialize the unified document processor
-        doc_processor = DocumentProcessor()
-        
-        # Run diagnosis if requested
+        kernel = CiteWeaveKernel()
+
         if args.diagnose:
             print("Running quality diagnosis...")
-            diagnosis = doc_processor.diagnose_document_processing(args.pdf_path)
-            
+            diagnosis = kernel.diagnose_document(args.pdf_path)
+
             print(f"Quality Level: {diagnosis['overall_assessment']['quality_level']}")
             print(f"Is Processable: {diagnosis['overall_assessment']['is_processable']}")
-            
+
             if diagnosis['overall_assessment']['recommendations']:
                 print("Recommendations:")
                 for rec in diagnosis['overall_assessment']['recommendations']:
                     print(f"  - {rec}")
-            
+
             if not diagnosis['overall_assessment']['is_processable']:
                 print("Warning: Document may not process well. Continue anyway? (y/n)")
                 response = input().strip().lower()
                 if response != 'y':
                     sys.exit(1)
-        
-        # Process the document
+
         print(f"Processing document: {args.pdf_path}")
-        results = doc_processor.process_document(args.pdf_path, save_results=True)
+        results = kernel.upload_document(args.pdf_path, save_results=True)
         
         # Display results
         stats = results['processing_stats']
@@ -344,13 +219,13 @@ def handle_upload_command(args):
         sys.exit(1)
 
 def handle_query_command(args):
-    """Handle the query command via the LangGraph research workflow."""
+    """Handle the query command via the kernel service."""
     confirmation = getattr(args, "confirmation", "continue") or "continue"
 
     try:
-        system = LangGraphResearchSystem()
+        kernel = CiteWeaveKernel()
         print(f"Querying: {args.question}")
-        response = system.research_question(args.question, confirmation)
+        response = kernel.query(args.question, confirmation)
         print()
         print(response)
     except Exception as e:
@@ -361,8 +236,8 @@ def handle_query_command(args):
 def handle_diagnose_command(args):
     """Handle the diagnose command."""
     try:
-        doc_processor = DocumentProcessor()
-        diagnosis = doc_processor.diagnose_document_processing(args.pdf_path)
+        kernel = CiteWeaveKernel()
+        diagnosis = kernel.diagnose_document(args.pdf_path)
         
         print(f"=== Document Processing Diagnosis ===")
         print(f"File: {args.pdf_path}")
@@ -398,7 +273,8 @@ def handle_diagnose_command(args):
 def handle_chat_command(args):
     """Handle the chat command for interactive multi-turn conversation (stateless AI version)."""
     try:
-        system = LangGraphResearchSystem()
+        kernel = CiteWeaveKernel()
+        system = kernel.start_chat_system()
         print("🤖 CiteWeave Multi-Agent Research System (Chat Mode)")
         print("=" * 60)
         print("Type 'exit' or 'quit' to end the chat.")
@@ -700,7 +576,8 @@ def handle_progress_command(args):
 
 def handle_routes_command(args):
     """Display the active route configuration for diagnostics."""
-    config = active_route_configuration()
+    kernel = CiteWeaveKernel()
+    config = kernel.routes_snapshot()
 
     if getattr(args, "json", False):
         print(json.dumps(config, indent=2, ensure_ascii=False, sort_keys=True))

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -142,6 +142,8 @@ def main():
     progress_parser = subparsers.add_parser("progress", help="View batch upload progress status.")
     progress_parser.add_argument("directory", type=str, help="Path to the directory to check progress for.")
     progress_parser.add_argument("--clear", action="store_true", help="Clear progress for this directory.")
+    progress_parser.add_argument("--json", action="store_true", help="Print machine-readable progress information as JSON.")
+    progress_parser.add_argument("--show-completed", action="store_true", help="Also list completed files in text output.")
 
     # Routes command
     routes_parser = subparsers.add_parser("routes", help="Show active route configuration.")
@@ -540,38 +542,48 @@ def process_files_parallel(pdf_files, num_processors, tracker):
 def handle_progress_command(args):
     """Handle the progress command to view batch upload progress status."""
     directory = args.directory
-    clear_progress = args.clear
 
     if not os.path.isdir(directory):
         print(f"Error: {directory} is not a valid directory.")
         sys.exit(1)
 
-    tracker = BatchUploadTracker(directory)
+    kernel = CiteWeaveKernel()
+    progress = kernel.progress_summary(directory, clear=args.clear)
+
+    if getattr(args, "json", False):
+        print(json.dumps(progress, indent=2, ensure_ascii=False, sort_keys=True))
+        return
 
     print(f"\n=== Batch Upload Progress for {directory} ===")
-    summary = tracker.get_progress_summary()
+    if progress["cleared"]:
+        print("Progress cleared before reporting.")
+
+    summary = progress["summary"]
+    print(f"Total PDF files discovered: {progress['total_pdf_files']}")
     print(f"Total files tracked: {summary['total_tracked']}")
-    print(f"Completed: {summary['completed']}")
-    print(f"Failed: {summary['failed']}")
+    print(f"Completed: {progress['completed_count']}")
+    print(f"Failed: {progress['failed_count']}")
+    print(f"Pending: {progress['pending_count']}")
     print(f"Success rate: {summary['success_rate']:.1f}%")
 
-    if clear_progress:
-        print("\nClearing progress for this directory...")
-        tracker.clear_progress(directory)
-        print("Progress cleared.")
-        summary = tracker.get_progress_summary()
-        print(f"Total files tracked after clearing: {summary['total_tracked']}")
-        print(f"Completed after clearing: {summary['completed']}")
-        print(f"Failed after clearing: {summary['failed']}")
-        print(f"Success rate after clearing: {summary['success_rate']:.1f}%")
+    if progress["failed_files"]:
+        print("\n--- Failed Files ---")
+        for idx, (pdf_path, error_msg) in enumerate(progress["failed_files"].items(), 1):
+            print(f"{idx}. {os.path.basename(pdf_path)}")
+            if error_msg:
+                print(f"   Error: {error_msg}")
 
     print("\n--- Pending Files ---")
-    pending_files = tracker.get_pending_files(glob.glob(os.path.join(directory, "**", "*.pdf"), recursive=True), force_restart=False)
-    if pending_files:
-        for i, pdf_path in enumerate(pending_files, 1):
+    if progress["pending_files"]:
+        for i, pdf_path in enumerate(progress["pending_files"], 1):
             print(f"{i}. {os.path.basename(pdf_path)}")
     else:
         print("No files pending processing.")
+
+    if getattr(args, "show_completed", False) and progress["completed_files"]:
+        print("\n--- Completed Files ---")
+        for i, pdf_path in enumerate(progress["completed_files"], 1):
+            print(f"{i}. {os.path.basename(pdf_path)}")
 
 
 def handle_routes_command(args):

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -65,7 +65,8 @@ def process_single_pdf_worker(pdf_path, diagnose=False, force=False):
     """
     try:
         logging.info(f"START: Processing PDF file {pdf_path}")
-        
+        started_at = time.time()
+
         # Initialize the document processor in the worker process
         doc_processor = DocumentProcessor()
         
@@ -74,6 +75,7 @@ def process_single_pdf_worker(pdf_path, diagnose=False, force=False):
         
         # Return success with basic stats
         stats = results.get('processing_stats', {})
+        finished_at = time.time()
         result_data = {
             'status': 'success',
             'pdf_path': pdf_path,
@@ -82,7 +84,9 @@ def process_single_pdf_worker(pdf_path, diagnose=False, force=False):
             'sentences_with_citations': stats.get('sentences_with_citations', 0),
             'total_citations': stats.get('total_citations', 0),
             'total_references': stats.get('total_references', 0),
-            'processing_time': time.time()  # Add timestamp for tracking
+            'processed_at': finished_at,
+            'processing_time': finished_at,
+            'duration_seconds': round(finished_at - started_at, 3),
         }
         
         logging.info(f"FINISH: Successfully processed {pdf_path} - Paper ID: {result_data['paper_id']}, Sentences: {result_data['total_sentences']}, Citations: {result_data['total_citations']}")
@@ -468,6 +472,7 @@ def process_files_sequentially(pdf_files, tracker):
 
     for idx, pdf_path in enumerate(pdf_files, 1):
         print(f"\n[{idx}/{len(pdf_files)}] Processing: {pdf_path}")
+        started_at = time.time()
         try:
             print(f"Processing document: {pdf_path}")
             results = kernel.upload_document(pdf_path, save_results=True)
@@ -493,11 +498,14 @@ def process_files_sequentially(pdf_files, tracker):
                         ref = cite.get('reference', {})
                         print(f"   → {cite.get('intext', '')} → {ref.get('title', 'Unknown')[:50]}... ({ref.get('year', 'Unknown')})")
 
+            finished_at = time.time()
             tracker.mark_file_completed(
                 pdf_path,
                 {
                     'paper_id': results.get('paper_id'),
-                    'processing_time': time.time(),
+                    'processed_at': finished_at,
+                    'processing_time': finished_at,
+                    'duration_seconds': round(finished_at - started_at, 3),
                     'total_sentences': stats.get('total_sentences', 0),
                     'sentences_with_citations': stats.get('sentences_with_citations', 0),
                     'total_citations': stats.get('total_citations', 0),
@@ -600,6 +608,13 @@ def handle_progress_command(args):
     print(f"  • Not started yet: {progress['not_started_count']}")
     print(f"  • Retryable failed files: {progress['retryable_failed_count']}")
     print(f"Success rate: {summary['success_rate']:.1f}%")
+
+    average_completed_duration_seconds = progress.get("average_completed_duration_seconds")
+    estimated_remaining_seconds = progress.get("estimated_remaining_seconds")
+    if average_completed_duration_seconds is not None:
+        print(f"Observed average time per completed file: {average_completed_duration_seconds:.1f}s")
+    if estimated_remaining_seconds is not None:
+        print(f"Estimated remaining wall time: {estimated_remaining_seconds:.1f}s")
 
     aggregate_stats = summary.get("aggregate_stats", {})
     if aggregate_stats:

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -12,6 +12,7 @@ import threading
 import time
 import multiprocessing
 import json
+from datetime import datetime, timezone
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from functools import partial
 from pathlib import Path
@@ -165,6 +166,7 @@ def main():
     query_history_parser = subparsers.add_parser("query-history", help="Inspect recent query telemetry from the local JSONL history log.")
     query_history_parser.add_argument("--limit", type=int, default=10, help="How many recent query records to include (default: 10).")
     query_history_parser.add_argument("--status", choices=["all", "success", "error", "corrupt"], default="all", help="Filter to a specific query status (default: all).")
+    query_history_parser.add_argument("--since-hours", type=float, default=None, help="Only include query records from the last N hours.")
     query_history_parser.add_argument("--json", action="store_true", help="Print machine-readable query history as JSON.")
 
     args = parser.parse_args()
@@ -816,12 +818,41 @@ def handle_bootstrap_plan_command(args):
     print()
 
 
+def _format_query_history_timestamp(timestamp):
+    if not isinstance(timestamp, (int, float)):
+        return ""
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+
+def _format_relative_age(timestamp):
+    if not isinstance(timestamp, (int, float)):
+        return ""
+
+    delta_seconds = max(0, int(time.time() - timestamp))
+    if delta_seconds < 60:
+        return "just now"
+    if delta_seconds < 3600:
+        minutes = delta_seconds // 60
+        return f"{minutes}m ago"
+    if delta_seconds < 86400:
+        hours = delta_seconds // 3600
+        minutes = (delta_seconds % 3600) // 60
+        return f"{hours}h {minutes}m ago" if minutes else f"{hours}h ago"
+    days = delta_seconds // 86400
+    hours = (delta_seconds % 86400) // 3600
+    return f"{days}d {hours}h ago" if hours else f"{days}d ago"
+
+
+
 def handle_query_history_command(args):
     """Display recent query telemetry from the local query history log."""
     kernel = CiteWeaveKernel()
+    since_hours = getattr(args, "since_hours", None)
     snapshot = kernel.query_history_snapshot(
         limit=max(0, getattr(args, "limit", 10)),
         status=getattr(args, "status", "all") or "all",
+        since_hours=since_hours,
     )
 
     if getattr(args, "json", False):
@@ -832,6 +863,8 @@ def handle_query_history_command(args):
     print(f"Log file: {snapshot.get('log_file', '')}")
     print(f"Requested limit: {snapshot.get('requested_limit', 0)}")
     print(f"Status filter: {snapshot.get('status_filter', 'all')}")
+    if snapshot.get("since_hours") is not None:
+        print(f"Time window: last {snapshot.get('since_hours')} hours")
     print(f"Entries returned: {snapshot.get('entries_returned', 0)}")
     print(f"Successful queries: {snapshot.get('success_count', 0)}")
     print(f"Failed queries: {snapshot.get('error_count', 0)}")
@@ -865,7 +898,11 @@ def handle_query_history_command(args):
         duration = entry.get("duration_ms")
         question = entry.get("question") or entry.get("raw_line") or ""
         duration_text = f" ({duration} ms)" if isinstance(duration, int) else ""
-        print(f"{idx}. [{status}]{duration_text} {question}")
+        timestamp_text = _format_query_history_timestamp(entry.get("timestamp"))
+        relative_age = _format_relative_age(entry.get("timestamp"))
+        when_text = f" at {timestamp_text}" if timestamp_text else ""
+        age_text = f" [{relative_age}]" if relative_age else ""
+        print(f"{idx}. [{status}]{duration_text}{when_text}{age_text} {question}")
 
     print()
 

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -448,36 +448,57 @@ def handle_batch_upload_command(args):
     logging.info("FINISH: Batch upload command completed")
 
 def process_files_sequentially(pdf_files, tracker):
-    """Process files sequentially (original behavior)."""
+    """Process files sequentially while preserving real tracker statistics."""
     print("Starting sequential batch upload...")
     success_count = 0
     fail_count = 0
-    
+    kernel = CiteWeaveKernel()
+
     for idx, pdf_path in enumerate(pdf_files, 1):
         print(f"\n[{idx}/{len(pdf_files)}] Processing: {pdf_path}")
         try:
-            class Args:
-                pass
-            file_args = Args()
-            file_args.pdf_path = pdf_path
-            file_args.diagnose = False
-            file_args.force = False
-            handle_upload_command(file_args)
+            print(f"Processing document: {pdf_path}")
+            results = kernel.upload_document(pdf_path, save_results=True)
+            stats = results.get('processing_stats', {})
+
+            print(f"\nProcessing completed successfully!")
+            print(f"Paper ID: {results['paper_id']}")
+            print(f"Total sentences: {stats.get('total_sentences', 0)}")
+            print(f"Sentences with citations: {stats.get('sentences_with_citations', 0)}")
+            print(f"Total citations found: {stats.get('total_citations', 0)}")
+            print(f"Total references: {stats.get('total_references', 0)}")
+
+            sentences_with_cites = [
+                s for s in results.get('sentences_with_citations', []) if s.get('citations')
+            ]
+            if not results.get('sentences_with_citations'):
+                print("Warning: No 'sentences_with_citations' found in results. This document may not contain any extracted citation sentences.")
+            if sentences_with_cites:
+                print(f"\nExample sentences with citations:")
+                for i, sentence in enumerate(sentences_with_cites[:3]):
+                    print(f"\n{i+1}. {sentence.get('sentence_text', '')[:100]}...")
+                    for cite in sentence.get('citations', []):
+                        ref = cite.get('reference', {})
+                        print(f"   → {cite.get('intext', '')} → {ref.get('title', 'Unknown')[:50]}... ({ref.get('year', 'Unknown')})")
+
+            tracker.mark_file_completed(
+                pdf_path,
+                {
+                    'paper_id': results.get('paper_id'),
+                    'processing_time': time.time(),
+                    'total_sentences': stats.get('total_sentences', 0),
+                    'sentences_with_citations': stats.get('sentences_with_citations', 0),
+                    'total_citations': stats.get('total_citations', 0),
+                    'total_references': stats.get('total_references', 0),
+                },
+            )
             success_count += 1
-            
-            # Mark as completed in tracker
-            result = {
-                'paper_id': 'unknown',  # We don't have detailed results from handle_upload_command
-                'total_sentences': 0,
-                'total_citations': 0
-            }
-            tracker.mark_file_completed(pdf_path, result)
-            
+
         except Exception as e:
             print(f"Failed to process {pdf_path}: {e}")
             fail_count += 1
             tracker.mark_file_failed(pdf_path, e)
-    
+
     print(f"\nBatch upload complete. Success: {success_count}, Failed: {fail_count}")
 
 def process_files_parallel(pdf_files, num_processors, tracker):

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -161,6 +161,11 @@ def main():
     bootstrap_parser = subparsers.add_parser("bootstrap-plan", help="Show the recommended local and OpenClaw bootstrap steps.")
     bootstrap_parser.add_argument("--json", action="store_true", help="Print machine-readable bootstrap plan as JSON.")
 
+    # Query history command
+    query_history_parser = subparsers.add_parser("query-history", help="Inspect recent query telemetry from the local JSONL history log.")
+    query_history_parser.add_argument("--limit", type=int, default=10, help="How many recent query records to include (default: 10).")
+    query_history_parser.add_argument("--json", action="store_true", help="Print machine-readable query history as JSON.")
+
     args = parser.parse_args()
 
     if args.command == "upload":
@@ -181,6 +186,8 @@ def main():
         handle_health_command(args)
     elif args.command == "bootstrap-plan":
         handle_bootstrap_plan_command(args)
+    elif args.command == "query-history":
+        handle_query_history_command(args)
     else:
         parser.print_help()
 
@@ -805,6 +812,52 @@ def handle_bootstrap_plan_command(args):
             print("next steps:")
             for step in next_steps:
                 print(f"  - {step}")
+    print()
+
+
+def handle_query_history_command(args):
+    """Display recent query telemetry from the local query history log."""
+    kernel = CiteWeaveKernel()
+    snapshot = kernel.query_history_snapshot(limit=max(0, getattr(args, "limit", 10)))
+
+    if getattr(args, "json", False):
+        print(json.dumps(snapshot, indent=2, ensure_ascii=False, sort_keys=True))
+        return
+
+    print("\n=== CiteWeave Query History ===\n")
+    print(f"Log file: {snapshot.get('log_file', '')}")
+    print(f"Requested limit: {snapshot.get('requested_limit', 0)}")
+    print(f"Entries returned: {snapshot.get('entries_returned', 0)}")
+    print(f"Successful queries: {snapshot.get('success_count', 0)}")
+    print(f"Failed queries: {snapshot.get('error_count', 0)}")
+    print(f"Corrupt rows skipped into diagnostics: {snapshot.get('corrupt_count', 0)}")
+
+    average_duration_ms = snapshot.get("average_duration_ms")
+    max_duration_ms = snapshot.get("max_duration_ms")
+    if average_duration_ms is not None:
+        print(f"Average duration: {average_duration_ms} ms")
+    if max_duration_ms is not None:
+        print(f"Slowest query: {max_duration_ms} ms")
+
+    latest_status = snapshot.get("latest_status")
+    latest_question = snapshot.get("latest_question")
+    if latest_status or latest_question:
+        print(f"Latest query: {latest_status or 'unknown'} — {latest_question or ''}")
+
+    entries = snapshot.get("entries", [])
+    if not entries:
+        print("\nNo query history recorded yet.")
+        print()
+        return
+
+    print("\nRecent entries:")
+    for idx, entry in enumerate(entries, 1):
+        status = entry.get("status", "unknown")
+        duration = entry.get("duration_ms")
+        question = entry.get("question") or entry.get("raw_line") or ""
+        duration_text = f" ({duration} ms)" if isinstance(duration, int) else ""
+        print(f"{idx}. [{status}]{duration_text} {question}")
+
     print()
 
 

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -149,6 +149,14 @@ def main():
     routes_parser = subparsers.add_parser("routes", help="Show active route configuration.")
     routes_parser.add_argument("--json", action="store_true", help="Print machine-readable route configuration as JSON.")
 
+    # Health command
+    health_parser = subparsers.add_parser("health", help="Show machine-readable service and environment health.")
+    health_parser.add_argument("--json", action="store_true", help="Print machine-readable health information as JSON.")
+
+    # Bootstrap plan command
+    bootstrap_parser = subparsers.add_parser("bootstrap-plan", help="Show the recommended local and OpenClaw bootstrap steps.")
+    bootstrap_parser.add_argument("--json", action="store_true", help="Print machine-readable bootstrap plan as JSON.")
+
     args = parser.parse_args()
 
     if args.command == "upload":
@@ -165,6 +173,10 @@ def main():
         handle_progress_command(args)
     elif args.command == "routes":
         handle_routes_command(args)
+    elif args.command == "health":
+        handle_health_command(args)
+    elif args.command == "bootstrap-plan":
+        handle_bootstrap_plan_command(args)
     else:
         parser.print_help()
 
@@ -689,6 +701,68 @@ def handle_routes_command(args):
             detail = f": {issue.get('detail')}" if issue.get("detail") else ""
             print(f"  {issue['reason']}{loc}{detail}")
 
+    print()
+
+
+def handle_health_command(args):
+    """Display machine-readable CiteWeave service and environment health."""
+    kernel = CiteWeaveKernel()
+    snapshot = kernel.health_snapshot()
+
+    if getattr(args, "json", False):
+        print(json.dumps(snapshot, indent=2, ensure_ascii=False, sort_keys=True))
+        return
+
+    env = snapshot.get("env", {})
+    files = snapshot.get("files", {})
+    services = snapshot.get("services", {})
+
+    print("\n=== CiteWeave Health Snapshot ===\n")
+    print(f"Project root: {snapshot.get('project_root', '')}")
+    print(f"LLM provider: {env.get('llm_provider') or 'unknown'}")
+    if env.get("llm_model"):
+        print(f"LLM model: {env['llm_model']}")
+    if env.get("gateway_base"):
+        print(f"Gateway base: {env['gateway_base']}")
+
+    if files:
+        print("\nFiles:")
+        for name, exists in files.items():
+            status = "present" if exists else "missing"
+            print(f"  {name}: {status}")
+
+    if services:
+        print("\nServices:")
+        for name, result in services.items():
+            if result is None:
+                continue
+            state = "ok" if result.get("ok") else "down"
+            status = result.get("status")
+            status_text = f"status={status}" if status is not None else "status=unavailable"
+            detail = f" error={result['error']}" if result.get("error") else ""
+            print(f"  {name}: {state} ({status_text}){detail}")
+
+    print()
+
+
+def handle_bootstrap_plan_command(args):
+    """Display recommended local and OpenClaw bootstrap steps."""
+    kernel = CiteWeaveKernel()
+    plan = kernel.bootstrap_plan()
+
+    if getattr(args, "json", False):
+        print(json.dumps(plan, indent=2, ensure_ascii=False, sort_keys=True))
+        return
+
+    print("\n=== CiteWeave Bootstrap Plan ===")
+    for section_name, section in plan.items():
+        print(f"\n[{section_name}]")
+        print(f"script: {section.get('script', '')}")
+        next_steps = section.get("next_steps", [])
+        if next_steps:
+            print("next steps:")
+            for step in next_steps:
+                print(f"  - {step}")
     print()
 
 

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -596,7 +596,9 @@ def handle_progress_command(args):
     print(f"Total files tracked: {summary['total_tracked']}")
     print(f"Completed: {progress['completed_count']}")
     print(f"Failed: {progress['failed_count']}")
-    print(f"Pending: {progress['pending_count']}")
+    print(f"Pending / resumable: {progress['pending_count']}")
+    print(f"  • Not started yet: {progress['not_started_count']}")
+    print(f"  • Retryable failed files: {progress['retryable_failed_count']}")
     print(f"Success rate: {summary['success_rate']:.1f}%")
 
     aggregate_stats = summary.get("aggregate_stats", {})
@@ -626,12 +628,29 @@ def handle_progress_command(args):
             if error_msg:
                 print(f"   Error: {error_msg}")
 
+    print("\n--- Retryable Failed Files ---")
+    if progress["retryable_failed_files"]:
+        for i, pdf_path in enumerate(progress["retryable_failed_files"], 1):
+            print(f"{i}. {os.path.basename(pdf_path)}")
+    else:
+        print("No failed files need a retry.")
+
+    print("\n--- Not Started Yet ---")
+    if progress["not_started_files"]:
+        for i, pdf_path in enumerate(progress["not_started_files"], 1):
+            print(f"{i}. {os.path.basename(pdf_path)}")
+    else:
+        print("No untouched files remain.")
+
     print("\n--- Pending Files ---")
     if progress["pending_files"]:
         for i, pdf_path in enumerate(progress["pending_files"], 1):
             print(f"{i}. {os.path.basename(pdf_path)}")
     else:
         print("No files pending processing.")
+
+    if progress["pending_count"] > 0:
+        print("\nTip: run batch-upload --resume to continue remaining files, including retries for previous failures.")
 
     if getattr(args, "show_completed", False) and progress["completed_files"]:
         print("\n--- Completed Files ---")

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -164,6 +164,7 @@ def main():
     # Query history command
     query_history_parser = subparsers.add_parser("query-history", help="Inspect recent query telemetry from the local JSONL history log.")
     query_history_parser.add_argument("--limit", type=int, default=10, help="How many recent query records to include (default: 10).")
+    query_history_parser.add_argument("--status", choices=["all", "success", "error", "corrupt"], default="all", help="Filter to a specific query status (default: all).")
     query_history_parser.add_argument("--json", action="store_true", help="Print machine-readable query history as JSON.")
 
     args = parser.parse_args()
@@ -818,7 +819,10 @@ def handle_bootstrap_plan_command(args):
 def handle_query_history_command(args):
     """Display recent query telemetry from the local query history log."""
     kernel = CiteWeaveKernel()
-    snapshot = kernel.query_history_snapshot(limit=max(0, getattr(args, "limit", 10)))
+    snapshot = kernel.query_history_snapshot(
+        limit=max(0, getattr(args, "limit", 10)),
+        status=getattr(args, "status", "all") or "all",
+    )
 
     if getattr(args, "json", False):
         print(json.dumps(snapshot, indent=2, ensure_ascii=False, sort_keys=True))
@@ -827,6 +831,7 @@ def handle_query_history_command(args):
     print("\n=== CiteWeave Query History ===\n")
     print(f"Log file: {snapshot.get('log_file', '')}")
     print(f"Requested limit: {snapshot.get('requested_limit', 0)}")
+    print(f"Status filter: {snapshot.get('status_filter', 'all')}")
     print(f"Entries returned: {snapshot.get('entries_returned', 0)}")
     print(f"Successful queries: {snapshot.get('success_count', 0)}")
     print(f"Failed queries: {snapshot.get('error_count', 0)}")
@@ -842,7 +847,11 @@ def handle_query_history_command(args):
     latest_status = snapshot.get("latest_status")
     latest_question = snapshot.get("latest_question")
     if latest_status or latest_question:
-        print(f"Latest query: {latest_status or 'unknown'} — {latest_question or ''}")
+        print(f"Latest query: {latest_status or 'unknown'} - {latest_question or ''}")
+
+    latest_error = snapshot.get("latest_error")
+    if latest_error:
+        print(f"Latest error: {latest_error}")
 
     entries = snapshot.get("entries", [])
     if not entries:

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -713,17 +713,25 @@ def handle_health_command(args):
         print(json.dumps(snapshot, indent=2, ensure_ascii=False, sort_keys=True))
         return
 
+    summary = snapshot.get("summary", {})
     env = snapshot.get("env", {})
     files = snapshot.get("files", {})
     services = snapshot.get("services", {})
 
     print("\n=== CiteWeave Health Snapshot ===\n")
+    print(f"Overall status: {summary.get('overall_status', 'unknown')}")
     print(f"Project root: {snapshot.get('project_root', '')}")
     print(f"LLM provider: {env.get('llm_provider') or 'unknown'}")
     if env.get("llm_model"):
         print(f"LLM model: {env['llm_model']}")
     if env.get("gateway_base"):
         print(f"Gateway base: {env['gateway_base']}")
+
+    action_items = summary.get("action_items", [])
+    if action_items:
+        print("\nRecommended next actions:")
+        for item in action_items:
+            print(f"  - {item}")
 
     if files:
         print("\nFiles:")

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -566,6 +566,26 @@ def handle_progress_command(args):
     print(f"Pending: {progress['pending_count']}")
     print(f"Success rate: {summary['success_rate']:.1f}%")
 
+    aggregate_stats = summary.get("aggregate_stats", {})
+    if aggregate_stats:
+        print("\n--- Completed Workload ---")
+        print(f"Total sentences processed: {aggregate_stats.get('total_sentences', 0)}")
+        print(f"Sentences with citations: {aggregate_stats.get('sentences_with_citations', 0)}")
+        print(f"Total citations found: {aggregate_stats.get('total_citations', 0)}")
+        print(f"Total references found: {aggregate_stats.get('total_references', 0)}")
+
+    last_completed = summary.get("last_completed")
+    if last_completed:
+        print("\n--- Last Completed File ---")
+        print(f"File: {os.path.basename(last_completed['pdf_path'])}")
+        if last_completed.get("paper_id"):
+            print(f"Paper ID: {last_completed['paper_id']}")
+
+    if summary.get("failure_reasons"):
+        print("\n--- Failure Reasons ---")
+        for item in summary["failure_reasons"]:
+            print(f"- {item['count']} × {item['error']}")
+
     if progress["failed_files"]:
         print("\n--- Failed Files ---")
         for idx, (pdf_path, error_msg) in enumerate(progress["failed_files"].items(), 1):

--- a/src/kernel/__init__.py
+++ b/src/kernel/__init__.py
@@ -1,0 +1,11 @@
+"""CiteWeave kernel layer.
+
+This package exposes stable, adapter-agnostic application services.
+CLI, OpenClaw, future HTTP APIs, and other entrypoints should depend on this
+layer instead of reaching directly into scattered processing/agent modules.
+"""
+
+from .service import CiteWeaveKernel
+from .batch_tracker import BatchUploadTracker
+
+__all__ = ["CiteWeaveKernel", "BatchUploadTracker"]

--- a/src/kernel/__init__.py
+++ b/src/kernel/__init__.py
@@ -7,5 +7,6 @@ layer instead of reaching directly into scattered processing/agent modules.
 
 from .service import CiteWeaveKernel
 from .batch_tracker import BatchUploadTracker
+from .query_history import QueryHistoryRecorder
 
-__all__ = ["CiteWeaveKernel", "BatchUploadTracker"]
+__all__ = ["CiteWeaveKernel", "BatchUploadTracker", "QueryHistoryRecorder"]

--- a/src/kernel/batch_tracker.py
+++ b/src/kernel/batch_tracker.py
@@ -12,6 +12,10 @@ from pathlib import Path
 from typing import Dict, Any
 
 
+_STATUS_COMPLETED = "completed"
+_STATUS_FAILED = "failed"
+
+
 class BatchUploadTracker:
     """Tracks batch upload progress to enable resuming interrupted uploads."""
 
@@ -52,7 +56,7 @@ class BatchUploadTracker:
 
     def mark_file_completed(self, pdf_path: str, result_data: Dict[str, Any]) -> None:
         self.progress_data[pdf_path] = {
-            "status": "completed",
+            "status": _STATUS_COMPLETED,
             "directory": self.directory,
             "paper_id": result_data.get("paper_id"),
             "processed_at": result_data.get("processing_time"),
@@ -67,32 +71,53 @@ class BatchUploadTracker:
 
     def mark_file_failed(self, pdf_path: str, error_msg: str) -> None:
         self.progress_data[pdf_path] = {
-            "status": "failed",
+            "status": _STATUS_FAILED,
             "directory": self.directory,
             "error": error_msg,
         }
         self._save_progress()
 
     def is_file_completed(self, pdf_path: str) -> bool:
-        return pdf_path in self.progress_data and self.progress_data[pdf_path]["status"] == "completed"
+        return pdf_path in self.progress_data and self.progress_data[pdf_path]["status"] == _STATUS_COMPLETED
 
     def is_file_failed(self, pdf_path: str) -> bool:
-        return pdf_path in self.progress_data and self.progress_data[pdf_path]["status"] == "failed"
+        return pdf_path in self.progress_data and self.progress_data[pdf_path]["status"] == _STATUS_FAILED
 
     def get_pending_files(self, all_files, force_restart: bool = False):
         if force_restart:
             return all_files
         return [pdf_path for pdf_path in all_files if not self.is_file_completed(pdf_path)]
 
+    def completed_entries(self) -> Dict[str, Any]:
+        return {
+            path: entry
+            for path, entry in self.progress_data.items()
+            if entry.get("status") == _STATUS_COMPLETED
+        }
+
+    def failed_entries(self) -> Dict[str, Any]:
+        return {
+            path: entry
+            for path, entry in self.progress_data.items()
+            if entry.get("status") == _STATUS_FAILED
+        }
+
     def get_progress_summary(self):
+        completed_entries = self.completed_entries()
+        failed_entries = self.failed_entries()
         total = len(self.progress_data)
-        completed = sum(1 for v in self.progress_data.values() if v["status"] == "completed")
-        failed = sum(1 for v in self.progress_data.values() if v["status"] == "failed")
+        completed = len(completed_entries)
+        failed = len(failed_entries)
         return {
             "total_tracked": total,
             "completed": completed,
             "failed": failed,
             "success_rate": (completed / total * 100) if total > 0 else 0,
+            "completed_files": sorted(completed_entries.keys()),
+            "failed_files": {
+                path: entry.get("error", "")
+                for path, entry in sorted(failed_entries.items())
+            },
         }
 
     def clear_progress(self, directory: str | None = None) -> None:

--- a/src/kernel/batch_tracker.py
+++ b/src/kernel/batch_tracker.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import Counter
 from pathlib import Path
 from typing import Dict, Any
 
@@ -73,7 +74,7 @@ class BatchUploadTracker:
         self.progress_data[pdf_path] = {
             "status": _STATUS_FAILED,
             "directory": self.directory,
-            "error": error_msg,
+            "error": str(error_msg),
         }
         self._save_progress()
 
@@ -108,6 +109,37 @@ class BatchUploadTracker:
         total = len(self.progress_data)
         completed = len(completed_entries)
         failed = len(failed_entries)
+
+        aggregate_stats = {
+            "total_sentences": 0,
+            "sentences_with_citations": 0,
+            "total_citations": 0,
+            "total_references": 0,
+        }
+        last_completed = None
+        for path, entry in completed_entries.items():
+            stats = entry.get("stats", {})
+            aggregate_stats["total_sentences"] += int(stats.get("total_sentences", 0) or 0)
+            aggregate_stats["sentences_with_citations"] += int(stats.get("sentences_with_citations", 0) or 0)
+            aggregate_stats["total_citations"] += int(stats.get("total_citations", 0) or 0)
+            aggregate_stats["total_references"] += int(stats.get("total_references", 0) or 0)
+
+            processed_at = entry.get("processed_at")
+            if processed_at is None:
+                continue
+            if last_completed is None or processed_at > last_completed["processed_at"]:
+                last_completed = {
+                    "pdf_path": path,
+                    "paper_id": entry.get("paper_id"),
+                    "processed_at": processed_at,
+                    "stats": stats,
+                }
+
+        error_counter = Counter(
+            entry.get("error", "") or "unknown error"
+            for entry in failed_entries.values()
+        )
+
         return {
             "total_tracked": total,
             "completed": completed,
@@ -118,6 +150,12 @@ class BatchUploadTracker:
                 path: entry.get("error", "")
                 for path, entry in sorted(failed_entries.items())
             },
+            "aggregate_stats": aggregate_stats,
+            "last_completed": last_completed,
+            "failure_reasons": [
+                {"error": error, "count": count}
+                for error, count in error_counter.most_common()
+            ],
         }
 
     def clear_progress(self, directory: str | None = None) -> None:

--- a/src/kernel/batch_tracker.py
+++ b/src/kernel/batch_tracker.py
@@ -56,11 +56,14 @@ class BatchUploadTracker:
             json.dump(all_data, f, indent=2, ensure_ascii=False)
 
     def mark_file_completed(self, pdf_path: str, result_data: Dict[str, Any]) -> None:
+        processed_at = result_data.get("processed_at", result_data.get("processing_time"))
+        duration_seconds = result_data.get("duration_seconds")
         self.progress_data[pdf_path] = {
             "status": _STATUS_COMPLETED,
             "directory": self.directory,
             "paper_id": result_data.get("paper_id"),
-            "processed_at": result_data.get("processing_time"),
+            "processed_at": processed_at,
+            "duration_seconds": float(duration_seconds) if duration_seconds is not None else None,
             "stats": {
                 "total_sentences": result_data.get("total_sentences", 0),
                 "sentences_with_citations": result_data.get("sentences_with_citations", 0),
@@ -117,12 +120,19 @@ class BatchUploadTracker:
             "total_references": 0,
         }
         last_completed = None
+        total_duration_seconds = 0.0
+        completed_with_duration = 0
         for path, entry in completed_entries.items():
             stats = entry.get("stats", {})
             aggregate_stats["total_sentences"] += int(stats.get("total_sentences", 0) or 0)
             aggregate_stats["sentences_with_citations"] += int(stats.get("sentences_with_citations", 0) or 0)
             aggregate_stats["total_citations"] += int(stats.get("total_citations", 0) or 0)
             aggregate_stats["total_references"] += int(stats.get("total_references", 0) or 0)
+
+            duration_seconds = entry.get("duration_seconds")
+            if duration_seconds is not None:
+                total_duration_seconds += float(duration_seconds)
+                completed_with_duration += 1
 
             processed_at = entry.get("processed_at")
             if processed_at is None:
@@ -132,6 +142,7 @@ class BatchUploadTracker:
                     "pdf_path": path,
                     "paper_id": entry.get("paper_id"),
                     "processed_at": processed_at,
+                    "duration_seconds": duration_seconds,
                     "stats": stats,
                 }
 
@@ -151,6 +162,8 @@ class BatchUploadTracker:
                 for path, entry in sorted(failed_entries.items())
             },
             "aggregate_stats": aggregate_stats,
+            "total_completed_duration_seconds": round(total_duration_seconds, 3),
+            "average_completed_duration_seconds": round(total_duration_seconds / completed_with_duration, 3) if completed_with_duration else None,
             "last_completed": last_completed,
             "failure_reasons": [
                 {"error": error, "count": count}

--- a/src/kernel/batch_tracker.py
+++ b/src/kernel/batch_tracker.py
@@ -1,0 +1,103 @@
+"""Batch upload progress tracker.
+
+Moved out of CLI so progress bookkeeping belongs to the kernel/application
+layer rather than the terminal adapter.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Any
+
+
+class BatchUploadTracker:
+    """Tracks batch upload progress to enable resuming interrupted uploads."""
+
+    def __init__(self, directory: str, tracker_file: str | None = None):
+        self.directory = directory
+        if tracker_file is None:
+            data_dir = Path("data")
+            data_dir.mkdir(exist_ok=True)
+            self.tracker_file = data_dir / "batch_upload_tracker.json"
+        else:
+            self.tracker_file = Path(tracker_file)
+
+        self.progress_data = self._load_progress()
+
+    def _load_progress(self) -> Dict[str, Any]:
+        if self.tracker_file.exists():
+            try:
+                with open(self.tracker_file, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                    return {k: v for k, v in data.items() if v.get("directory") == self.directory}
+            except (json.JSONDecodeError, IOError) as e:
+                logging.warning("Could not load progress tracker: %s", e)
+                return {}
+        return {}
+
+    def _save_progress(self) -> None:
+        try:
+            all_data = {}
+            if self.tracker_file.exists():
+                with open(self.tracker_file, "r", encoding="utf-8") as f:
+                    all_data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            all_data = {}
+
+        all_data.update(self.progress_data)
+        with open(self.tracker_file, "w", encoding="utf-8") as f:
+            json.dump(all_data, f, indent=2, ensure_ascii=False)
+
+    def mark_file_completed(self, pdf_path: str, result_data: Dict[str, Any]) -> None:
+        self.progress_data[pdf_path] = {
+            "status": "completed",
+            "directory": self.directory,
+            "paper_id": result_data.get("paper_id"),
+            "processed_at": result_data.get("processing_time"),
+            "stats": {
+                "total_sentences": result_data.get("total_sentences", 0),
+                "sentences_with_citations": result_data.get("sentences_with_citations", 0),
+                "total_citations": result_data.get("total_citations", 0),
+                "total_references": result_data.get("total_references", 0),
+            },
+        }
+        self._save_progress()
+
+    def mark_file_failed(self, pdf_path: str, error_msg: str) -> None:
+        self.progress_data[pdf_path] = {
+            "status": "failed",
+            "directory": self.directory,
+            "error": error_msg,
+        }
+        self._save_progress()
+
+    def is_file_completed(self, pdf_path: str) -> bool:
+        return pdf_path in self.progress_data and self.progress_data[pdf_path]["status"] == "completed"
+
+    def is_file_failed(self, pdf_path: str) -> bool:
+        return pdf_path in self.progress_data and self.progress_data[pdf_path]["status"] == "failed"
+
+    def get_pending_files(self, all_files, force_restart: bool = False):
+        if force_restart:
+            return all_files
+        return [pdf_path for pdf_path in all_files if not self.is_file_completed(pdf_path)]
+
+    def get_progress_summary(self):
+        total = len(self.progress_data)
+        completed = sum(1 for v in self.progress_data.values() if v["status"] == "completed")
+        failed = sum(1 for v in self.progress_data.values() if v["status"] == "failed")
+        return {
+            "total_tracked": total,
+            "completed": completed,
+            "failed": failed,
+            "success_rate": (completed / total * 100) if total > 0 else 0,
+        }
+
+    def clear_progress(self, directory: str | None = None) -> None:
+        if directory:
+            self.progress_data = {k: v for k, v in self.progress_data.items() if v.get("directory") != directory}
+        else:
+            self.progress_data = {}
+        self._save_progress()

--- a/src/kernel/query_history.py
+++ b/src/kernel/query_history.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -43,18 +44,36 @@ class QueryHistoryRecorder:
                 })
         return entries
 
-    def recent_entries(self, limit: int = 10, status: Optional[str] = None) -> List[Dict[str, Any]]:
+    def recent_entries(
+        self,
+        limit: int = 10,
+        status: Optional[str] = None,
+        since_hours: Optional[float] = None,
+        now: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
         if limit <= 0:
             return []
 
         entries = self.load_entries()
         if status and status != "all":
             entries = [entry for entry in entries if entry.get("status") == status]
+        if since_hours is not None and since_hours >= 0:
+            cutoff = (time.time() if now is None else now) - (since_hours * 3600)
+            entries = [
+                entry for entry in entries
+                if isinstance(entry.get("timestamp"), (int, float)) and entry["timestamp"] >= cutoff
+            ]
         return list(reversed(entries[-limit:]))
 
-    def summary(self, limit: int = 10, status: Optional[str] = None) -> Dict[str, Any]:
+    def summary(
+        self,
+        limit: int = 10,
+        status: Optional[str] = None,
+        since_hours: Optional[float] = None,
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
         status_filter = status or "all"
-        recent = self.recent_entries(limit=limit, status=status_filter)
+        recent = self.recent_entries(limit=limit, status=status_filter, since_hours=since_hours, now=now)
         considered = [entry for entry in recent if entry.get("status") != "corrupt"]
         success_count = sum(1 for entry in considered if entry.get("status") == "success")
         error_count = sum(1 for entry in considered if entry.get("status") == "error")
@@ -68,6 +87,7 @@ class QueryHistoryRecorder:
             "status_filter": status_filter,
             "entries_returned": len(recent),
             "entries_considered": len(considered),
+            "since_hours": since_hours,
             "success_count": success_count,
             "error_count": error_count,
             "corrupt_count": len(recent) - len(considered),

--- a/src/kernel/query_history.py
+++ b/src/kernel/query_history.py
@@ -1,0 +1,26 @@
+"""Query history recorder for CiteWeave runtime telemetry.
+
+This stays in the kernel layer so CLI/OpenClaw/other entrypoints can reuse a
+single recorder without inventing their own file formats.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+
+class QueryHistoryRecorder:
+    """Append query interaction records to a local JSONL log file."""
+
+    def __init__(self, log_file: str | None = None):
+        if log_file is None:
+            log_file = os.environ.get("CITEWEAVE_QUERY_HISTORY_FILE", "data/query_history.jsonl")
+        self.log_file = Path(log_file)
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    def record(self, entry: Dict[str, Any]) -> None:
+        with self.log_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/src/kernel/query_history.py
+++ b/src/kernel/query_history.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class QueryHistoryRecorder:
@@ -43,23 +43,29 @@ class QueryHistoryRecorder:
                 })
         return entries
 
-    def recent_entries(self, limit: int = 10) -> List[Dict[str, Any]]:
+    def recent_entries(self, limit: int = 10, status: Optional[str] = None) -> List[Dict[str, Any]]:
         if limit <= 0:
             return []
+
         entries = self.load_entries()
+        if status and status != "all":
+            entries = [entry for entry in entries if entry.get("status") == status]
         return list(reversed(entries[-limit:]))
 
-    def summary(self, limit: int = 10) -> Dict[str, Any]:
-        recent = self.recent_entries(limit=limit)
+    def summary(self, limit: int = 10, status: Optional[str] = None) -> Dict[str, Any]:
+        status_filter = status or "all"
+        recent = self.recent_entries(limit=limit, status=status_filter)
         considered = [entry for entry in recent if entry.get("status") != "corrupt"]
         success_count = sum(1 for entry in considered if entry.get("status") == "success")
         error_count = sum(1 for entry in considered if entry.get("status") == "error")
         durations = [entry.get("duration_ms") for entry in considered if isinstance(entry.get("duration_ms"), int)]
         latest = considered[0] if considered else None
+        latest_error = next((entry for entry in recent if entry.get("status") == "error"), None)
 
         return {
             "log_file": str(self.log_file),
             "requested_limit": limit,
+            "status_filter": status_filter,
             "entries_returned": len(recent),
             "entries_considered": len(considered),
             "success_count": success_count,
@@ -69,5 +75,6 @@ class QueryHistoryRecorder:
             "max_duration_ms": max(durations) if durations else None,
             "latest_status": latest.get("status") if latest else None,
             "latest_question": latest.get("question") if latest else None,
+            "latest_error": latest_error.get("error") if latest_error else None,
             "entries": recent,
         }

--- a/src/kernel/query_history.py
+++ b/src/kernel/query_history.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 class QueryHistoryRecorder:
@@ -24,3 +24,50 @@ class QueryHistoryRecorder:
     def record(self, entry: Dict[str, Any]) -> None:
         with self.log_file.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    def load_entries(self) -> List[Dict[str, Any]]:
+        if not self.log_file.exists():
+            return []
+
+        entries: List[Dict[str, Any]] = []
+        for line in self.log_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                entries.append({
+                    "status": "corrupt",
+                    "raw_line": line,
+                })
+        return entries
+
+    def recent_entries(self, limit: int = 10) -> List[Dict[str, Any]]:
+        if limit <= 0:
+            return []
+        entries = self.load_entries()
+        return list(reversed(entries[-limit:]))
+
+    def summary(self, limit: int = 10) -> Dict[str, Any]:
+        recent = self.recent_entries(limit=limit)
+        considered = [entry for entry in recent if entry.get("status") != "corrupt"]
+        success_count = sum(1 for entry in considered if entry.get("status") == "success")
+        error_count = sum(1 for entry in considered if entry.get("status") == "error")
+        durations = [entry.get("duration_ms") for entry in considered if isinstance(entry.get("duration_ms"), int)]
+        latest = considered[0] if considered else None
+
+        return {
+            "log_file": str(self.log_file),
+            "requested_limit": limit,
+            "entries_returned": len(recent),
+            "entries_considered": len(considered),
+            "success_count": success_count,
+            "error_count": error_count,
+            "corrupt_count": len(recent) - len(considered),
+            "average_duration_ms": round(sum(durations) / len(durations), 2) if durations else None,
+            "max_duration_ms": max(durations) if durations else None,
+            "latest_status": latest.get("status") if latest else None,
+            "latest_question": latest.get("question") if latest else None,
+            "entries": recent,
+        }

--- a/src/kernel/query_history.py
+++ b/src/kernel/query_history.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -48,6 +49,7 @@ class QueryHistoryRecorder:
         self,
         limit: int = 10,
         status: Optional[str] = None,
+        source: Optional[str] = None,
         since_hours: Optional[float] = None,
         now: Optional[float] = None,
     ) -> List[Dict[str, Any]]:
@@ -57,6 +59,8 @@ class QueryHistoryRecorder:
         entries = self.load_entries()
         if status and status != "all":
             entries = [entry for entry in entries if entry.get("status") == status]
+        if source and source != "all":
+            entries = [entry for entry in entries if (entry.get("source") or "unknown") == source]
         if since_hours is not None and since_hours >= 0:
             cutoff = (time.time() if now is None else now) - (since_hours * 3600)
             entries = [
@@ -69,22 +73,33 @@ class QueryHistoryRecorder:
         self,
         limit: int = 10,
         status: Optional[str] = None,
+        source: Optional[str] = None,
         since_hours: Optional[float] = None,
         now: Optional[float] = None,
     ) -> Dict[str, Any]:
         status_filter = status or "all"
-        recent = self.recent_entries(limit=limit, status=status_filter, since_hours=since_hours, now=now)
+        source_filter = source or "all"
+        recent = self.recent_entries(
+            limit=limit,
+            status=status_filter,
+            source=source_filter,
+            since_hours=since_hours,
+            now=now,
+        )
         considered = [entry for entry in recent if entry.get("status") != "corrupt"]
         success_count = sum(1 for entry in considered if entry.get("status") == "success")
         error_count = sum(1 for entry in considered if entry.get("status") == "error")
         durations = [entry.get("duration_ms") for entry in considered if isinstance(entry.get("duration_ms"), int)]
         latest = considered[0] if considered else None
         latest_error = next((entry for entry in recent if entry.get("status") == "error"), None)
+        source_counter = Counter((entry.get("source") or "unknown") for entry in considered)
+        confirmation_counter = Counter((entry.get("confirmation") or "unspecified") for entry in considered)
 
         return {
             "log_file": str(self.log_file),
             "requested_limit": limit,
             "status_filter": status_filter,
+            "source_filter": source_filter,
             "entries_returned": len(recent),
             "entries_considered": len(considered),
             "since_hours": since_hours,
@@ -95,6 +110,15 @@ class QueryHistoryRecorder:
             "max_duration_ms": max(durations) if durations else None,
             "latest_status": latest.get("status") if latest else None,
             "latest_question": latest.get("question") if latest else None,
+            "latest_source": latest.get("source") if latest else None,
             "latest_error": latest_error.get("error") if latest_error else None,
+            "source_breakdown": [
+                {"source": source_name, "count": count}
+                for source_name, count in source_counter.most_common()
+            ],
+            "confirmation_breakdown": [
+                {"confirmation": confirmation, "count": count}
+                for confirmation, count in confirmation_counter.most_common()
+            ],
             "entries": recent,
         }

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -19,6 +19,7 @@ from src.processing.pdf.document_processor import DocumentProcessor
 from src.agents.multi_agent_research_system import LangGraphResearchSystem
 from src.agents.routing import active_route_configuration
 from .batch_tracker import BatchUploadTracker
+from .query_history import QueryHistoryRecorder
 
 
 class CiteWeaveKernel:
@@ -47,7 +48,40 @@ class CiteWeaveKernel:
         return self.document_processor.diagnose_document_processing(pdf_path)
 
     def query(self, question: str, confirmation: str = "continue") -> str:
-        return self.research_system.research_question(question, confirmation)
+        started_at = time.time()
+        recorder = QueryHistoryRecorder()
+
+        try:
+            response = self.research_system.research_question(question, confirmation)
+        except Exception as exc:
+            recorder.record(
+                {
+                    "timestamp": started_at,
+                    "question": question,
+                    "confirmation": confirmation,
+                    "status": "error",
+                    "duration_ms": int((time.time() - started_at) * 1000),
+                    "response_chars": 0,
+                    "response_preview": "",
+                    "error": str(exc),
+                    "satisfaction": None,
+                }
+            )
+            raise
+
+        recorder.record(
+            {
+                "timestamp": started_at,
+                "question": question,
+                "confirmation": confirmation,
+                "status": "success",
+                "duration_ms": int((time.time() - started_at) * 1000),
+                "response_chars": len(response),
+                "response_preview": response[:500],
+                "satisfaction": None,
+            }
+        )
+        return response
 
     def start_chat_system(self) -> LangGraphResearchSystem:
         return self.research_system

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -255,6 +255,11 @@ class CiteWeaveKernel:
             "estimated_remaining_seconds": estimated_remaining_seconds,
         }
 
-    def query_history_snapshot(self, limit: int = 10, status: str = "all") -> Dict[str, Any]:
+    def query_history_snapshot(
+        self,
+        limit: int = 10,
+        status: str = "all",
+        since_hours: Optional[float] = None,
+    ) -> Dict[str, Any]:
         recorder = QueryHistoryRecorder()
-        return recorder.summary(limit=limit, status=status)
+        return recorder.summary(limit=limit, status=status, since_hours=since_hours)

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -189,6 +189,10 @@ class CiteWeaveKernel:
         all_files = glob.glob(os.path.join(directory, "**", "*.pdf"), recursive=True)
         summary = tracker.get_progress_summary()
         pending_files = tracker.get_pending_files(all_files, force_restart=False)
+        failed_files = summary["failed_files"]
+        failed_paths = set(failed_files.keys())
+        not_started_files = sorted(pdf_path for pdf_path in all_files if pdf_path not in tracker.progress_data)
+        retryable_failed_files = sorted(pdf_path for pdf_path in all_files if pdf_path in failed_paths)
 
         return {
             "directory": directory,
@@ -197,8 +201,12 @@ class CiteWeaveKernel:
             "summary": summary,
             "pending_count": len(pending_files),
             "pending_files": sorted(pending_files),
+            "not_started_count": len(not_started_files),
+            "not_started_files": not_started_files,
+            "retryable_failed_count": len(retryable_failed_files),
+            "retryable_failed_files": retryable_failed_files,
             "completed_count": summary["completed"],
             "completed_files": summary["completed_files"],
             "failed_count": summary["failed"],
-            "failed_files": summary["failed_files"],
+            "failed_files": failed_files,
         }

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -108,13 +108,17 @@ class CiteWeaveKernel:
         processed = []
         failed = []
         for pdf_path in pending_files:
+            started_at = time.time()
             try:
                 result = self.upload_document(pdf_path, save_results=True)
+                finished_at = time.time()
                 stats = result.get("processing_stats", {})
                 compact = {
                     "pdf_path": pdf_path,
                     "paper_id": result.get("paper_id"),
-                    "processing_time": time.time(),
+                    "processed_at": finished_at,
+                    "processing_time": finished_at,
+                    "duration_seconds": round(finished_at - started_at, 3),
                     "total_sentences": stats.get("total_sentences", 0),
                     "sentences_with_citations": stats.get("sentences_with_citations", 0),
                     "total_citations": stats.get("total_citations", 0),
@@ -227,6 +231,10 @@ class CiteWeaveKernel:
         failed_paths = set(failed_files.keys())
         not_started_files = sorted(pdf_path for pdf_path in all_files if pdf_path not in tracker.progress_data)
         retryable_failed_files = sorted(pdf_path for pdf_path in all_files if pdf_path in failed_paths)
+        average_completed_duration_seconds = summary.get("average_completed_duration_seconds")
+        estimated_remaining_seconds = None
+        if average_completed_duration_seconds is not None and pending_files:
+            estimated_remaining_seconds = round(float(average_completed_duration_seconds) * len(pending_files), 3)
 
         return {
             "directory": directory,
@@ -243,4 +251,6 @@ class CiteWeaveKernel:
             "completed_files": summary["completed_files"],
             "failed_count": summary["failed"],
             "failed_files": failed_files,
+            "average_completed_duration_seconds": average_completed_duration_seconds,
+            "estimated_remaining_seconds": estimated_remaining_seconds,
         }

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -254,3 +254,7 @@ class CiteWeaveKernel:
             "average_completed_duration_seconds": average_completed_duration_seconds,
             "estimated_remaining_seconds": estimated_remaining_seconds,
         }
+
+    def query_history_snapshot(self, limit: int = 10) -> Dict[str, Any]:
+        recorder = QueryHistoryRecorder()
+        return recorder.summary(limit=limit)

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -154,16 +154,22 @@ class CiteWeaveKernel:
 
     def progress_summary(self, directory: str, clear: bool = False) -> Dict[str, Any]:
         tracker = BatchUploadTracker(directory)
-        summary_before = tracker.get_progress_summary()
         if clear:
             tracker.clear_progress(directory)
-        pending_files = tracker.get_pending_files(
-            glob.glob(os.path.join(directory, "**", "*.pdf"), recursive=True),
-            force_restart=False,
-        )
+
+        all_files = glob.glob(os.path.join(directory, "**", "*.pdf"), recursive=True)
+        summary = tracker.get_progress_summary()
+        pending_files = tracker.get_pending_files(all_files, force_restart=False)
+
         return {
             "directory": directory,
-            "summary": tracker.get_progress_summary() if clear else summary_before,
-            "pending_files": pending_files,
             "cleared": clear,
+            "total_pdf_files": len(all_files),
+            "summary": summary,
+            "pending_count": len(pending_files),
+            "pending_files": sorted(pending_files),
+            "completed_count": summary["completed"],
+            "completed_files": summary["completed_files"],
+            "failed_count": summary["failed"],
+            "failed_files": summary["failed_files"],
         }

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import glob
 import os
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib import request, error
 
 from src.processing.pdf.document_processor import DocumentProcessor
 from src.agents.multi_agent_research_system import LangGraphResearchSystem
@@ -51,6 +53,104 @@ class CiteWeaveKernel:
 
     def routes_snapshot(self) -> Dict[str, Any]:
         return active_route_configuration()
+
+    def chat_turn(self, user_input: str, history: Optional[list] = None, menu_choice: Optional[str] = None, collected_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        return self.research_system.interactive_research_chat(
+            user_input,
+            history=history,
+            menu_choice=menu_choice,
+            collected_data=collected_data,
+        )
+
+    def batch_upload(self, directory: str, resume: bool = True, force_restart: bool = False, clear_progress: bool = False) -> Dict[str, Any]:
+        tracker = BatchUploadTracker(directory)
+        if clear_progress:
+            tracker.clear_progress(directory)
+
+        all_files = glob.glob(os.path.join(directory, "**", "*.pdf"), recursive=True)
+        pending_files = tracker.get_pending_files(all_files, force_restart=force_restart or not resume)
+
+        processed = []
+        failed = []
+        for pdf_path in pending_files:
+            try:
+                result = self.upload_document(pdf_path, save_results=True)
+                stats = result.get("processing_stats", {})
+                compact = {
+                    "pdf_path": pdf_path,
+                    "paper_id": result.get("paper_id"),
+                    "total_sentences": stats.get("total_sentences", 0),
+                    "total_citations": stats.get("total_citations", 0),
+                }
+                tracker.mark_file_completed(pdf_path, compact)
+                processed.append(compact)
+            except Exception as e:
+                tracker.mark_file_failed(pdf_path, str(e))
+                failed.append({"pdf_path": pdf_path, "error": str(e)})
+
+        return {
+            "directory": directory,
+            "total_files": len(all_files),
+            "processed_count": len(processed),
+            "failed_count": len(failed),
+            "processed": processed,
+            "failed": failed,
+            "summary": tracker.get_progress_summary(),
+        }
+
+    def health_snapshot(self) -> Dict[str, Any]:
+        def probe(url: str) -> Dict[str, Any]:
+            try:
+                with request.urlopen(url, timeout=5) as resp:
+                    return {"ok": True, "status": resp.getcode(), "url": url}
+            except error.HTTPError as e:
+                return {"ok": False, "status": e.code, "url": url, "error": str(e)}
+            except Exception as e:
+                return {"ok": False, "status": None, "url": url, "error": str(e)}
+
+        env_mode = os.environ.get("CITEWEAVE_LLM_PROVIDER", "openai")
+        gateway_url = os.environ.get("CITEWEAVE_LLM_API_BASE", "http://localhost:18789/v1").rstrip("/")
+
+        return {
+            "project_root": str(Path.cwd()),
+            "env": {
+                "llm_provider": env_mode,
+                "llm_model": os.environ.get("CITEWEAVE_LLM_MODEL", ""),
+                "gateway_base": gateway_url if env_mode == "openclaw" else None,
+            },
+            "files": {
+                ".env": Path('.env').exists(),
+                "docker_compose": Path('docker-compose.yml').exists(),
+                "model_config": Path('config/model_config.json').exists(),
+                "neo4j_config": Path('config/neo4j_config.json').exists(),
+            },
+            "services": {
+                "qdrant": probe("http://localhost:6333/collections"),
+                "grobid": probe("http://localhost:8070/api/isalive"),
+                "neo4j_http": probe("http://localhost:7474"),
+                "openclaw_gateway": probe(gateway_url + "/models") if env_mode == "openclaw" else None,
+            },
+        }
+
+    def bootstrap_plan(self) -> Dict[str, Any]:
+        return {
+            "local_cli": {
+                "script": "bash scripts/bootstrap_local.sh",
+                "next_steps": [
+                    ".venv/bin/python -m src.core.cli upload path/to/paper.pdf",
+                    '.venv/bin/python -m src.core.cli query "<question>"',
+                    ".venv/bin/python -m src.core.cli chat",
+                ],
+            },
+            "openclaw": {
+                "script": "bash scripts/bootstrap_openclaw.sh",
+                "next_steps": [
+                    "openclaw gateway status",
+                    ".venv/bin/python -m src.core.cli routes",
+                    "bash scripts/deployment_check.sh",
+                ],
+            },
+        }
 
     def progress_summary(self, directory: str, clear: bool = False) -> Dict[str, Any]:
         tracker = BatchUploadTracker(directory)

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -47,7 +47,7 @@ class CiteWeaveKernel:
     def diagnose_document(self, pdf_path: str) -> Dict[str, Any]:
         return self.document_processor.diagnose_document_processing(pdf_path)
 
-    def query(self, question: str, confirmation: str = "continue") -> str:
+    def query(self, question: str, confirmation: str = "continue", source: str = "kernel.query") -> str:
         started_at = time.time()
         recorder = QueryHistoryRecorder()
 
@@ -60,6 +60,7 @@ class CiteWeaveKernel:
                     "question": question,
                     "confirmation": confirmation,
                     "status": "error",
+                    "source": source,
                     "duration_ms": int((time.time() - started_at) * 1000),
                     "response_chars": 0,
                     "response_preview": "",
@@ -75,6 +76,7 @@ class CiteWeaveKernel:
                 "question": question,
                 "confirmation": confirmation,
                 "status": "success",
+                "source": source,
                 "duration_ms": int((time.time() - started_at) * 1000),
                 "response_chars": len(response),
                 "response_preview": response[:500],
@@ -259,7 +261,8 @@ class CiteWeaveKernel:
         self,
         limit: int = 10,
         status: str = "all",
+        source: str = "all",
         since_hours: Optional[float] = None,
     ) -> Dict[str, Any]:
         recorder = QueryHistoryRecorder()
-        return recorder.summary(limit=limit, status=status, since_hours=since_hours)
+        return recorder.summary(limit=limit, status=status, source=source, since_hours=since_hours)

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -255,6 +255,6 @@ class CiteWeaveKernel:
             "estimated_remaining_seconds": estimated_remaining_seconds,
         }
 
-    def query_history_snapshot(self, limit: int = 10) -> Dict[str, Any]:
+    def query_history_snapshot(self, limit: int = 10, status: str = "all") -> Dict[str, Any]:
         recorder = QueryHistoryRecorder()
-        return recorder.summary(limit=limit)
+        return recorder.summary(limit=limit, status=status)

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -1,0 +1,69 @@
+"""CiteWeave kernel service.
+
+This is the adapter-neutral application layer for the project.
+Entry points such as the CLI, OpenClaw integration, and future HTTP APIs
+should call this service instead of directly composing processing and agent
+objects on their own.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import Any, Dict
+
+from src.processing.pdf.document_processor import DocumentProcessor
+from src.agents.multi_agent_research_system import LangGraphResearchSystem
+from src.agents.routing import active_route_configuration
+from .batch_tracker import BatchUploadTracker
+
+
+class CiteWeaveKernel:
+    """Stable application service boundary for CiteWeave."""
+
+    def __init__(self):
+        self._document_processor = None
+        self._research_system = None
+
+    @property
+    def document_processor(self) -> DocumentProcessor:
+        if self._document_processor is None:
+            self._document_processor = DocumentProcessor()
+        return self._document_processor
+
+    @property
+    def research_system(self) -> LangGraphResearchSystem:
+        if self._research_system is None:
+            self._research_system = LangGraphResearchSystem()
+        return self._research_system
+
+    def upload_document(self, pdf_path: str, save_results: bool = True) -> Dict[str, Any]:
+        return self.document_processor.process_document(pdf_path, save_results=save_results)
+
+    def diagnose_document(self, pdf_path: str) -> Dict[str, Any]:
+        return self.document_processor.diagnose_document_processing(pdf_path)
+
+    def query(self, question: str, confirmation: str = "continue") -> str:
+        return self.research_system.research_question(question, confirmation)
+
+    def start_chat_system(self) -> LangGraphResearchSystem:
+        return self.research_system
+
+    def routes_snapshot(self) -> Dict[str, Any]:
+        return active_route_configuration()
+
+    def progress_summary(self, directory: str, clear: bool = False) -> Dict[str, Any]:
+        tracker = BatchUploadTracker(directory)
+        summary_before = tracker.get_progress_summary()
+        if clear:
+            tracker.clear_progress(directory)
+        pending_files = tracker.get_pending_files(
+            glob.glob(os.path.join(directory, "**", "*.pdf"), recursive=True),
+            force_restart=False,
+        )
+        return {
+            "directory": directory,
+            "summary": tracker.get_progress_summary() if clear else summary_before,
+            "pending_files": pending_files,
+            "cleared": clear,
+        }

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import glob
 import os
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib import request, error
@@ -79,8 +80,11 @@ class CiteWeaveKernel:
                 compact = {
                     "pdf_path": pdf_path,
                     "paper_id": result.get("paper_id"),
+                    "processing_time": time.time(),
                     "total_sentences": stats.get("total_sentences", 0),
+                    "sentences_with_citations": stats.get("sentences_with_citations", 0),
                     "total_citations": stats.get("total_citations", 0),
+                    "total_references": stats.get("total_references", 0),
                 }
                 tracker.mark_file_completed(pdf_path, compact)
                 processed.append(compact)

--- a/src/kernel/service.py
+++ b/src/kernel/service.py
@@ -115,25 +115,50 @@ class CiteWeaveKernel:
         env_mode = os.environ.get("CITEWEAVE_LLM_PROVIDER", "openai")
         gateway_url = os.environ.get("CITEWEAVE_LLM_API_BASE", "http://localhost:18789/v1").rstrip("/")
 
+        files = {
+            ".env": Path('.env').exists(),
+            "docker_compose": Path('docker-compose.yml').exists(),
+            "model_config": Path('config/model_config.json').exists(),
+            "neo4j_config": Path('config/neo4j_config.json').exists(),
+        }
+        services = {
+            "qdrant": probe("http://localhost:6333/collections"),
+            "grobid": probe("http://localhost:8070/api/isalive"),
+            "neo4j_http": probe("http://localhost:7474"),
+            "openclaw_gateway": probe(gateway_url + "/models") if env_mode == "openclaw" else None,
+        }
+
+        missing_files = [name for name, exists in files.items() if not exists]
+        down_services = [name for name, result in services.items() if result is not None and not result.get("ok")]
+
+        action_items = []
+        if missing_files:
+            action_items.append(f"Create or restore required config files: {', '.join(missing_files)}")
+        if down_services:
+            action_items.append(f"Start or fix backend services: {', '.join(down_services)}")
+        if not action_items:
+            action_items.append("System looks healthy. Continue with upload/query/chat commands.")
+
+        if missing_files or down_services:
+            overall_status = "degraded"
+        else:
+            overall_status = "ok"
+
         return {
             "project_root": str(Path.cwd()),
+            "summary": {
+                "overall_status": overall_status,
+                "missing_files": missing_files,
+                "down_services": down_services,
+                "action_items": action_items,
+            },
             "env": {
                 "llm_provider": env_mode,
                 "llm_model": os.environ.get("CITEWEAVE_LLM_MODEL", ""),
                 "gateway_base": gateway_url if env_mode == "openclaw" else None,
             },
-            "files": {
-                ".env": Path('.env').exists(),
-                "docker_compose": Path('docker-compose.yml').exists(),
-                "model_config": Path('config/model_config.json').exists(),
-                "neo4j_config": Path('config/neo4j_config.json').exists(),
-            },
-            "services": {
-                "qdrant": probe("http://localhost:6333/collections"),
-                "grobid": probe("http://localhost:8070/api/isalive"),
-                "neo4j_http": probe("http://localhost:7474"),
-                "openclaw_gateway": probe(gateway_url + "/models") if env_mode == "openclaw" else None,
-            },
+            "files": files,
+            "services": services,
         }
 
     def bootstrap_plan(self) -> Dict[str, Any]:

--- a/tests/test_batch_tracker_progress.py
+++ b/tests/test_batch_tracker_progress.py
@@ -196,8 +196,12 @@ def test_kernel_progress_summary_returns_actionable_breakdown():
         assert progress["completed_count"] == 1
         assert progress["failed_count"] == 1
         assert progress["pending_count"] == 2
+        assert progress["not_started_count"] == 1
+        assert progress["retryable_failed_count"] == 1
         assert str(pdf_dir / "ok.pdf") in progress["completed_files"]
         assert progress["failed_files"] == {str(pdf_dir / "bad.pdf"): "parse error"}
+        assert progress["retryable_failed_files"] == [str(pdf_dir / "bad.pdf")]
+        assert progress["not_started_files"] == [str(pdf_dir / "pending.pdf")]
         assert progress["pending_files"] == sorted([
             str(pdf_dir / "bad.pdf"),
             str(pdf_dir / "pending.pdf"),

--- a/tests/test_batch_tracker_progress.py
+++ b/tests/test_batch_tracker_progress.py
@@ -55,6 +55,15 @@ def test_batch_tracker_summary_includes_completed_and_failed_files():
         assert summary["failed"] == 1
         assert summary["completed_files"] == ["/papers/ok.pdf"]
         assert summary["failed_files"] == {"/papers/bad.pdf": "grobid timeout"}
+        assert summary["aggregate_stats"] == {
+            "total_sentences": 20,
+            "sentences_with_citations": 5,
+            "total_citations": 8,
+            "total_references": 10,
+        }
+        assert summary["last_completed"]["pdf_path"] == "/papers/ok.pdf"
+        assert summary["last_completed"]["paper_id"] == "paper-1"
+        assert summary["failure_reasons"] == [{"error": "grobid timeout", "count": 1}]
 
         persisted = json.loads(tracker_file.read_text(encoding="utf-8"))
         assert persisted["/papers/ok.pdf"]["paper_id"] == "paper-1"
@@ -84,7 +93,11 @@ def test_kernel_progress_summary_returns_actionable_breakdown():
     _stub_module("src.kernel", __path__=[])
     sys.modules["src.kernel.batch_tracker"] = batch_tracker
 
-    service = _load_module(SERVICE_PATH, "kernel_service")
+    service = _load_module(
+        SERVICE_PATH,
+        "kernel_service",
+        module_name=f"src.kernel.service_test_{uuid.uuid4().hex}",
+    )
 
     with tempfile.TemporaryDirectory() as tmpdir:
         pdf_dir = Path(tmpdir) / "papers"
@@ -124,3 +137,11 @@ def test_kernel_progress_summary_returns_actionable_breakdown():
             str(pdf_dir / "bad.pdf"),
             str(pdf_dir / "pending.pdf"),
         ])
+        assert progress["summary"]["aggregate_stats"] == {
+            "total_sentences": 10,
+            "sentences_with_citations": 0,
+            "total_citations": 2,
+            "total_references": 0,
+        }
+        assert progress["summary"]["last_completed"]["pdf_path"] == str(pdf_dir / "ok.pdf")
+        assert progress["summary"]["failure_reasons"] == [{"error": "parse error", "count": 1}]

--- a/tests/test_batch_tracker_progress.py
+++ b/tests/test_batch_tracker_progress.py
@@ -70,6 +70,71 @@ def test_batch_tracker_summary_includes_completed_and_failed_files():
         assert persisted["/papers/bad.pdf"]["error"] == "grobid timeout"
 
 
+def test_kernel_batch_upload_preserves_tracker_aggregate_stats():
+    batch_tracker = _load_module(
+        BATCH_TRACKER_PATH,
+        "batch_tracker",
+        module_name=f"src.kernel.batch_tracker_upload_{uuid.uuid4().hex}",
+    )
+
+    class DummyDocumentProcessor:
+        def process_document(self, pdf_path, save_results=True):
+            return {
+                "paper_id": "paper-1",
+                "processing_stats": {
+                    "total_sentences": 14,
+                    "sentences_with_citations": 6,
+                    "total_citations": 11,
+                    "total_references": 13,
+                },
+            }
+
+    class DummyResearchSystem:
+        pass
+
+    _stub_module("src", __path__=[])
+    _stub_module("src.processing", __path__=[])
+    _stub_module("src.processing.pdf", __path__=[])
+    _stub_module("src.processing.pdf.document_processor", DocumentProcessor=DummyDocumentProcessor)
+    _stub_module("src.agents", __path__=[])
+    _stub_module("src.agents.multi_agent_research_system", LangGraphResearchSystem=DummyResearchSystem)
+    _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
+    _stub_module("src.kernel", __path__=[])
+    sys.modules["src.kernel.batch_tracker"] = batch_tracker
+
+    service = _load_module(
+        SERVICE_PATH,
+        "kernel_service_upload",
+        module_name=f"src.kernel.service_upload_{uuid.uuid4().hex}",
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pdf_dir = Path(tmpdir) / "papers"
+        pdf_dir.mkdir()
+        (pdf_dir / "ok.pdf").write_bytes(b"%PDF-1.4 ok")
+
+        tracker_file = Path(tmpdir) / "tracker.json"
+        original_tracker_cls = service.BatchUploadTracker
+
+        service.BatchUploadTracker = lambda directory: batch_tracker.BatchUploadTracker(directory, tracker_file=str(tracker_file))
+        try:
+            kernel = service.CiteWeaveKernel()
+            result = kernel.batch_upload(str(pdf_dir), resume=False, force_restart=True)
+        finally:
+            service.BatchUploadTracker = original_tracker_cls
+
+        summary = result["summary"]
+        assert result["processed_count"] == 1
+        assert result["failed_count"] == 0
+        assert summary["aggregate_stats"] == {
+            "total_sentences": 14,
+            "sentences_with_citations": 6,
+            "total_citations": 11,
+            "total_references": 13,
+        }
+        assert summary["last_completed"]["paper_id"] == "paper-1"
+
+
 def test_kernel_progress_summary_returns_actionable_breakdown():
     batch_tracker = _load_module(
         BATCH_TRACKER_PATH,

--- a/tests/test_batch_tracker_progress.py
+++ b/tests/test_batch_tracker_progress.py
@@ -42,6 +42,7 @@ def test_batch_tracker_summary_includes_completed_and_failed_files():
             {
                 "paper_id": "paper-1",
                 "processing_time": 1234567890,
+                "duration_seconds": 3.5,
                 "total_sentences": 20,
                 "sentences_with_citations": 5,
                 "total_citations": 8,
@@ -62,12 +63,16 @@ def test_batch_tracker_summary_includes_completed_and_failed_files():
             "total_citations": 8,
             "total_references": 10,
         }
+        assert summary["total_completed_duration_seconds"] == 3.5
+        assert summary["average_completed_duration_seconds"] == 3.5
         assert summary["last_completed"]["pdf_path"] == "/papers/ok.pdf"
         assert summary["last_completed"]["paper_id"] == "paper-1"
+        assert summary["last_completed"]["duration_seconds"] == 3.5
         assert summary["failure_reasons"] == [{"error": "grobid timeout", "count": 1}]
 
         persisted = json.loads(tracker_file.read_text(encoding="utf-8"))
         assert persisted["/papers/ok.pdf"]["paper_id"] == "paper-1"
+        assert persisted["/papers/ok.pdf"]["duration_seconds"] == 3.5
         assert persisted["/papers/bad.pdf"]["error"] == "grobid timeout"
 
 
@@ -139,6 +144,7 @@ def test_kernel_batch_upload_preserves_tracker_aggregate_stats():
             "total_citations": 11,
             "total_references": 13,
         }
+        assert summary["average_completed_duration_seconds"] is not None
         assert summary["last_completed"]["paper_id"] == "paper-1"
 
 
@@ -188,7 +194,7 @@ def test_kernel_progress_summary_returns_actionable_breakdown():
         tracker = batch_tracker.BatchUploadTracker(str(pdf_dir), tracker_file=str(tracker_file))
         tracker.mark_file_completed(
             str(pdf_dir / "ok.pdf"),
-            {"paper_id": "paper-1", "processing_time": 1, "total_sentences": 10, "total_citations": 2},
+            {"paper_id": "paper-1", "processing_time": 1, "duration_seconds": 4.0, "total_sentences": 10, "total_citations": 2},
         )
         tracker.mark_file_failed(str(pdf_dir / "bad.pdf"), "parse error")
 
@@ -219,6 +225,8 @@ def test_kernel_progress_summary_returns_actionable_breakdown():
             str(pdf_dir / "bad.pdf"),
             str(pdf_dir / "pending.pdf"),
         ])
+        assert progress["average_completed_duration_seconds"] == 4.0
+        assert progress["estimated_remaining_seconds"] == 8.0
         assert progress["summary"]["aggregate_stats"] == {
             "total_sentences": 10,
             "sentences_with_citations": 0,
@@ -226,4 +234,5 @@ def test_kernel_progress_summary_returns_actionable_breakdown():
             "total_references": 0,
         }
         assert progress["summary"]["last_completed"]["pdf_path"] == str(pdf_dir / "ok.pdf")
+        assert progress["summary"]["last_completed"]["duration_seconds"] == 4.0
         assert progress["summary"]["failure_reasons"] == [{"error": "parse error", "count": 1}]

--- a/tests/test_batch_tracker_progress.py
+++ b/tests/test_batch_tracker_progress.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 BATCH_TRACKER_PATH = Path(__file__).resolve().parents[1] / "src" / "kernel" / "batch_tracker.py"
 SERVICE_PATH = Path(__file__).resolve().parents[1] / "src" / "kernel" / "service.py"
+QUERY_HISTORY_PATH = Path(__file__).resolve().parents[1] / "src" / "kernel" / "query_history.py"
 
 
 def _load_module(path: Path, prefix: str, module_name: str | None = None):
@@ -101,6 +102,12 @@ def test_kernel_batch_upload_preserves_tracker_aggregate_stats():
     _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
     _stub_module("src.kernel", __path__=[])
     sys.modules["src.kernel.batch_tracker"] = batch_tracker
+    query_history = _load_module(
+        QUERY_HISTORY_PATH,
+        "query_history",
+        module_name=f"src.kernel.query_history_upload_{uuid.uuid4().hex}",
+    )
+    sys.modules["src.kernel.query_history"] = query_history
 
     service = _load_module(
         SERVICE_PATH,
@@ -157,6 +164,12 @@ def test_kernel_progress_summary_returns_actionable_breakdown():
     _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
     _stub_module("src.kernel", __path__=[])
     sys.modules["src.kernel.batch_tracker"] = batch_tracker
+    query_history = _load_module(
+        QUERY_HISTORY_PATH,
+        "query_history",
+        module_name=f"src.kernel.query_history_test_{uuid.uuid4().hex}",
+    )
+    sys.modules["src.kernel.query_history"] = query_history
 
     service = _load_module(
         SERVICE_PATH,

--- a/tests/test_batch_tracker_progress.py
+++ b/tests/test_batch_tracker_progress.py
@@ -1,0 +1,126 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+import uuid
+from pathlib import Path
+
+
+BATCH_TRACKER_PATH = Path(__file__).resolve().parents[1] / "src" / "kernel" / "batch_tracker.py"
+SERVICE_PATH = Path(__file__).resolve().parents[1] / "src" / "kernel" / "service.py"
+
+
+def _load_module(path: Path, prefix: str, module_name: str | None = None):
+    effective_name = module_name or f"{prefix}_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(effective_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[effective_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stub_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def test_batch_tracker_summary_includes_completed_and_failed_files():
+    batch_tracker = _load_module(BATCH_TRACKER_PATH, "batch_tracker")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tracker_file = Path(tmpdir) / "tracker.json"
+        tracker = batch_tracker.BatchUploadTracker("/papers", tracker_file=str(tracker_file))
+
+        tracker.mark_file_completed(
+            "/papers/ok.pdf",
+            {
+                "paper_id": "paper-1",
+                "processing_time": 1234567890,
+                "total_sentences": 20,
+                "sentences_with_citations": 5,
+                "total_citations": 8,
+                "total_references": 10,
+            },
+        )
+        tracker.mark_file_failed("/papers/bad.pdf", "grobid timeout")
+
+        summary = tracker.get_progress_summary()
+
+        assert summary["completed"] == 1
+        assert summary["failed"] == 1
+        assert summary["completed_files"] == ["/papers/ok.pdf"]
+        assert summary["failed_files"] == {"/papers/bad.pdf": "grobid timeout"}
+
+        persisted = json.loads(tracker_file.read_text(encoding="utf-8"))
+        assert persisted["/papers/ok.pdf"]["paper_id"] == "paper-1"
+        assert persisted["/papers/bad.pdf"]["error"] == "grobid timeout"
+
+
+def test_kernel_progress_summary_returns_actionable_breakdown():
+    batch_tracker = _load_module(
+        BATCH_TRACKER_PATH,
+        "batch_tracker",
+        module_name=f"src.kernel.batch_tracker_test_{uuid.uuid4().hex}",
+    )
+
+    class DummyDocumentProcessor:
+        pass
+
+    class DummyResearchSystem:
+        pass
+
+    _stub_module("src", __path__=[])
+    _stub_module("src.processing", __path__=[])
+    _stub_module("src.processing.pdf", __path__=[])
+    _stub_module("src.processing.pdf.document_processor", DocumentProcessor=DummyDocumentProcessor)
+    _stub_module("src.agents", __path__=[])
+    _stub_module("src.agents.multi_agent_research_system", LangGraphResearchSystem=DummyResearchSystem)
+    _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
+    _stub_module("src.kernel", __path__=[])
+    sys.modules["src.kernel.batch_tracker"] = batch_tracker
+
+    service = _load_module(SERVICE_PATH, "kernel_service")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pdf_dir = Path(tmpdir) / "papers"
+        pdf_dir.mkdir()
+        (pdf_dir / "ok.pdf").write_bytes(b"%PDF-1.4 ok")
+        (pdf_dir / "bad.pdf").write_bytes(b"%PDF-1.4 bad")
+        (pdf_dir / "pending.pdf").write_bytes(b"%PDF-1.4 pending")
+
+        tracker_file = Path(tmpdir) / "tracker.json"
+        tracker = batch_tracker.BatchUploadTracker(str(pdf_dir), tracker_file=str(tracker_file))
+        tracker.mark_file_completed(
+            str(pdf_dir / "ok.pdf"),
+            {"paper_id": "paper-1", "processing_time": 1, "total_sentences": 10, "total_citations": 2},
+        )
+        tracker.mark_file_failed(str(pdf_dir / "bad.pdf"), "parse error")
+
+        original_tracker_cls = service.BatchUploadTracker
+        tracker_file_path = tracker_file
+
+        def tracker_factory(directory, tracker_file=None):
+            return batch_tracker.BatchUploadTracker(directory, tracker_file=str(tracker_file or tracker_file_path))
+
+        service.BatchUploadTracker = tracker_factory
+        try:
+            kernel = service.CiteWeaveKernel()
+            progress = kernel.progress_summary(str(pdf_dir))
+        finally:
+            service.BatchUploadTracker = original_tracker_cls
+
+        assert progress["total_pdf_files"] == 3
+        assert progress["completed_count"] == 1
+        assert progress["failed_count"] == 1
+        assert progress["pending_count"] == 2
+        assert str(pdf_dir / "ok.pdf") in progress["completed_files"]
+        assert progress["failed_files"] == {str(pdf_dir / "bad.pdf"): "parse error"}
+        assert progress["pending_files"] == sorted([
+            str(pdf_dir / "bad.pdf"),
+            str(pdf_dir / "pending.pdf"),
+        ])

--- a/tests/test_cli_batch_upload_sequential.py
+++ b/tests/test_cli_batch_upload_sequential.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+import types
+import unittest
+import uuid
+from pathlib import Path
+
+
+CLI_PATH = Path(__file__).resolve().parents[1] / "src" / "core" / "cli.py"
+
+
+def _stub_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class DummyTracker:
+    def __init__(self):
+        self.completed = []
+        self.failed = []
+
+    def mark_file_completed(self, pdf_path, result_data):
+        self.completed.append((pdf_path, result_data))
+
+    def mark_file_failed(self, pdf_path, error_msg):
+        self.failed.append((pdf_path, str(error_msg)))
+
+
+class FakeKernel:
+    def upload_document(self, pdf_path, save_results=True):
+        assert save_results is True
+        return {
+            "paper_id": f"paper:{Path(pdf_path).stem}",
+            "processing_stats": {
+                "total_sentences": 12,
+                "sentences_with_citations": 4,
+                "total_citations": 7,
+                "total_references": 9,
+            },
+            "sentences_with_citations": [
+                {
+                    "sentence_text": "Smith (2020) says useful things.",
+                    "citations": [
+                        {
+                            "intext": "Smith (2020)",
+                            "reference": {"title": "Useful Things", "year": "2020"},
+                        }
+                    ],
+                }
+            ],
+        }
+
+
+def _load_cli_module():
+    module_name = f"citeweave_cli_batch_{uuid.uuid4().hex}"
+
+    class DummyDocumentProcessor:
+        pass
+
+    class DummyLangGraphResearchSystem:
+        pass
+
+    _stub_module("prompt_toolkit", prompt=lambda *args, **kwargs: "")
+    _stub_module("src", __path__=[])
+    _stub_module("src.processing", __path__=[])
+    _stub_module("src.processing.pdf", __path__=[])
+    _stub_module("src.processing.pdf.document_processor", DocumentProcessor=DummyDocumentProcessor)
+    _stub_module("src.agents", __path__=[])
+    _stub_module("src.agents.multi_agent_research_system", LangGraphResearchSystem=DummyLangGraphResearchSystem)
+    _stub_module(
+        "src.agents.routing",
+        active_route_configuration=lambda: {
+            "default_route": "vector_search",
+            "valid_routes": [],
+            "aliases": {},
+            "priority_map": {},
+            "alias_overrides": {},
+            "priority_overrides": {},
+            "ignored_alias_overrides": [],
+            "ignored_priority_overrides": [],
+            "addon_config_paths": [],
+            "addon_config_issues": [],
+        },
+    )
+    _stub_module("src.kernel", CiteWeaveKernel=FakeKernel, BatchUploadTracker=DummyTracker)
+
+    spec = importlib.util.spec_from_file_location(module_name, CLI_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class CliBatchUploadSequentialTests(unittest.TestCase):
+    def test_process_files_sequentially_records_real_tracker_stats(self):
+        cli = _load_cli_module()
+        tracker = DummyTracker()
+
+        cli.process_files_sequentially(["/tmp/example.pdf"], tracker)
+
+        self.assertEqual(tracker.failed, [])
+        self.assertEqual(len(tracker.completed), 1)
+
+        pdf_path, result_data = tracker.completed[0]
+        self.assertEqual(pdf_path, "/tmp/example.pdf")
+        self.assertEqual(result_data["paper_id"], "paper:example")
+        self.assertEqual(result_data["total_sentences"], 12)
+        self.assertEqual(result_data["sentences_with_citations"], 4)
+        self.assertEqual(result_data["total_citations"], 7)
+        self.assertEqual(result_data["total_references"], 9)
+        self.assertIn("processing_time", result_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_batch_upload_sequential.py
+++ b/tests/test_cli_batch_upload_sequential.py
@@ -112,6 +112,8 @@ class CliBatchUploadSequentialTests(unittest.TestCase):
         self.assertEqual(result_data["total_citations"], 7)
         self.assertEqual(result_data["total_references"], 9)
         self.assertIn("processing_time", result_data)
+        self.assertIn("processed_at", result_data)
+        self.assertIn("duration_seconds", result_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -30,6 +30,21 @@ def _load_cli_module():
     class DummyLangGraphResearchSystem:
         pass
 
+    class FakeKernel:
+        def routes_snapshot(self):
+            return {
+                "default_route": "vector_search",
+                "valid_routes": [],
+                "aliases": {},
+                "priority_map": {},
+                "alias_overrides": {},
+                "priority_overrides": {},
+                "ignored_alias_overrides": [],
+                "ignored_priority_overrides": [],
+                "addon_config_paths": [],
+                "addon_config_issues": [],
+            }
+
     _stub_module("prompt_toolkit", prompt=lambda *args, **kwargs: "")
     _stub_module("src", __path__=[])
     _stub_module("src.processing", __path__=[])
@@ -52,6 +67,7 @@ def _load_cli_module():
             "addon_config_issues": [],
         },
     )
+    _stub_module("src.kernel", CiteWeaveKernel=FakeKernel, BatchUploadTracker=object)
 
     spec = importlib.util.spec_from_file_location(module_name, CLI_PATH)
     module = importlib.util.module_from_spec(spec)
@@ -76,7 +92,11 @@ class CliRoutesCommandTests(unittest.TestCase):
             "addon_config_issues": [],
         }
 
-        cli.active_route_configuration = lambda: expected
+        class ExpectedKernel:
+            def routes_snapshot(self):
+                return expected
+
+        cli.CiteWeaveKernel = ExpectedKernel
 
         buf = io.StringIO()
         with redirect_stdout(buf):

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -110,6 +110,15 @@ class CliHealthAndBootstrapCommandTests(unittest.TestCase):
         cli = _load_cli_module()
         expected = {
             "project_root": "/repo",
+            "summary": {
+                "overall_status": "degraded",
+                "missing_files": ["docker_compose"],
+                "down_services": ["openclaw_gateway"],
+                "action_items": [
+                    "Create or restore required config files: docker_compose",
+                    "Start or fix backend services: openclaw_gateway",
+                ],
+            },
             "env": {
                 "llm_provider": "openclaw",
                 "llm_model": "gpt-test",
@@ -133,6 +142,47 @@ class CliHealthAndBootstrapCommandTests(unittest.TestCase):
             cli.handle_health_command(Namespace(json=True))
 
         self.assertEqual(json.loads(buf.getvalue()), expected)
+
+    def test_handle_health_command_text_output_leads_with_status_and_actions(self):
+        cli = _load_cli_module()
+        expected = {
+            "project_root": "/repo",
+            "summary": {
+                "overall_status": "degraded",
+                "missing_files": ["docker_compose"],
+                "down_services": ["openclaw_gateway"],
+                "action_items": [
+                    "Create or restore required config files: docker_compose",
+                    "Start or fix backend services: openclaw_gateway",
+                ],
+            },
+            "env": {
+                "llm_provider": "openclaw",
+                "llm_model": "gpt-test",
+                "gateway_base": "http://localhost:18789/v1",
+            },
+            "files": {".env": True, "docker_compose": False},
+            "services": {
+                "qdrant": {"ok": True, "status": 200, "url": "http://localhost:6333/collections"},
+                "openclaw_gateway": {"ok": False, "status": 503, "url": "http://localhost:18789/v1/models", "error": "unavailable"},
+            },
+        }
+
+        class ExpectedKernel:
+            def health_snapshot(self):
+                return expected
+
+        cli.CiteWeaveKernel = ExpectedKernel
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.handle_health_command(Namespace(json=False))
+
+        output = buf.getvalue()
+        self.assertIn("Overall status: degraded", output)
+        self.assertIn("Recommended next actions:", output)
+        self.assertIn("Create or restore required config files: docker_compose", output)
+        self.assertIn("Start or fix backend services: openclaw_gateway", output)
 
     def test_handle_bootstrap_plan_command_supports_json_output(self):
         cli = _load_cli_module()

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -265,6 +265,7 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
             "log_file": "data/query_history.jsonl",
             "requested_limit": 5,
             "status_filter": "error",
+            "source_filter": "cli.query",
             "entries_returned": 2,
             "entries_considered": 2,
             "success_count": 0,
@@ -274,24 +275,28 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
             "max_duration_ms": 250,
             "latest_status": "error",
             "latest_question": "Why did retrieval fail?",
+            "latest_source": "cli.query",
             "latest_error": "retrieval unavailable",
+            "source_breakdown": [{"source": "cli.query", "count": 2}],
+            "confirmation_breakdown": [{"confirmation": "continue", "count": 2}],
             "entries": [
-                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250, "error": "retrieval unavailable"},
-                {"status": "error", "question": "Why did ranking fail?", "duration_ms": 200, "error": "timeout"},
+                {"status": "error", "source": "cli.query", "confirmation": "continue", "question": "Why did retrieval fail?", "duration_ms": 250, "error": "retrieval unavailable"},
+                {"status": "error", "source": "cli.query", "confirmation": "continue", "question": "Why did ranking fail?", "duration_ms": 200, "error": "timeout"},
             ],
         }
 
         class ExpectedKernel:
-            def query_history_snapshot(self, limit=10, status="all"):
+            def query_history_snapshot(self, limit=10, status="all", source="all"):
                 assert limit == 5
                 assert status == "error"
+                assert source == "cli.query"
                 return expected
 
         cli.CiteWeaveKernel = ExpectedKernel
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            cli.handle_query_history_command(Namespace(limit=5, status="error", json=True))
+            cli.handle_query_history_command(Namespace(limit=5, status="error", source="cli.query", json=True, since_hours=None))
 
         self.assertEqual(json.loads(buf.getvalue()), expected)
 
@@ -301,6 +306,7 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
             "log_file": "data/query_history.jsonl",
             "requested_limit": 2,
             "status_filter": "all",
+            "source_filter": "all",
             "entries_returned": 2,
             "entries_considered": 2,
             "success_count": 1,
@@ -310,35 +316,42 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
             "max_duration_ms": 250,
             "latest_status": "error",
             "latest_question": "Why did retrieval fail?",
+            "latest_source": "cli.query",
             "latest_error": "retrieval unavailable",
+            "source_breakdown": [{"source": "cli.query", "count": 2}],
+            "confirmation_breakdown": [{"confirmation": "continue", "count": 2}],
             "entries": [
-                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250, "error": "retrieval unavailable"},
-                {"status": "success", "question": "Summarize Porter", "duration_ms": 100},
+                {"status": "error", "source": "cli.query", "confirmation": "continue", "question": "Why did retrieval fail?", "duration_ms": 250, "error": "retrieval unavailable"},
+                {"status": "success", "source": "cli.query", "confirmation": "continue", "question": "Summarize Porter", "duration_ms": 100},
             ],
         }
 
         class ExpectedKernel:
-            def query_history_snapshot(self, limit=10, status="all"):
+            def query_history_snapshot(self, limit=10, status="all", source="all"):
                 assert limit == 2
                 assert status == "all"
+                assert source == "all"
                 return expected
 
         cli.CiteWeaveKernel = ExpectedKernel
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            cli.handle_query_history_command(Namespace(limit=2, status="all", json=False))
+            cli.handle_query_history_command(Namespace(limit=2, status="all", source="all", json=False, since_hours=None))
 
         output = buf.getvalue()
         self.assertIn("Status filter: all", output)
+        self.assertIn("Source filter: all", output)
         self.assertIn("Successful queries: 1", output)
         self.assertIn("Failed queries: 1", output)
         self.assertIn("Average duration: 175.0 ms", output)
         self.assertIn("Slowest query: 250 ms", output)
-        self.assertIn("Latest query: error - Why did retrieval fail?", output)
+        self.assertIn("Latest query: error [cli.query] - Why did retrieval fail?", output)
         self.assertIn("Latest error: retrieval unavailable", output)
-        self.assertIn("[error] (250 ms) Why did retrieval fail?", output)
-        self.assertIn("[success] (100 ms) Summarize Porter", output)
+        self.assertIn("Sources:", output)
+        self.assertIn("Confirmations:", output)
+        self.assertIn("[error] {cli.query} (250 ms) Why did retrieval fail?", output)
+        self.assertIn("[success] {cli.query} (100 ms) Summarize Porter", output)
 
 
 class CliHealthAndBootstrapCommandTests(unittest.TestCase):
@@ -451,15 +464,17 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
         cli = _load_cli_module()
 
         class ExpectedKernel:
-            def query_history_snapshot(self, limit=10, status="all", since_hours=None):
+            def query_history_snapshot(self, limit=10, status="all", source="all", since_hours=None):
                 assert limit == 5
                 assert status == "error"
+                assert source == "openclaw.facade.query"
                 assert since_hours == 24
                 return {
                     "log_file": "data/query_history.jsonl",
                     "requested_limit": limit,
                     "status_filter": status,
                     "since_hours": since_hours,
+                    "source_filter": source,
                     "entries_returned": 1,
                     "entries_considered": 1,
                     "success_count": 0,
@@ -469,10 +484,15 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
                     "max_duration_ms": 123,
                     "latest_status": "error",
                     "latest_question": "recent failure",
+                    "latest_source": "openclaw.facade.query",
                     "latest_error": "timeout",
+                    "source_breakdown": [{"source": "openclaw.facade.query", "count": 1}],
+                    "confirmation_breakdown": [{"confirmation": "continue", "count": 1}],
                     "entries": [
                         {
                             "status": "error",
+                            "source": "openclaw.facade.query",
+                            "confirmation": "continue",
                             "duration_ms": 123,
                             "question": "recent failure",
                             "timestamp": 1_800_000_000,
@@ -485,10 +505,11 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            cli.handle_query_history_command(Namespace(limit=5, status="error", since_hours=24, json=False))
+            cli.handle_query_history_command(Namespace(limit=5, status="error", source="openclaw.facade.query", since_hours=24, json=False))
 
         output = buf.getvalue()
         self.assertIn("Time window: last 24 hours", output)
+        self.assertIn("Source filter: openclaw.facade.query", output)
         self.assertIn("recent failure", output)
         self.assertIn("timeout", output)
 

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -45,11 +45,12 @@ def _load_cli_module():
                 "addon_config_issues": [],
             }
 
-        def query_history_snapshot(self, limit=10, status="all"):
+        def query_history_snapshot(self, limit=10, status="all", since_hours=None):
             return {
                 "log_file": "data/query_history.jsonl",
                 "requested_limit": limit,
                 "status_filter": status,
+                "since_hours": since_hours,
                 "entries_returned": 0,
                 "entries_considered": 0,
                 "success_count": 0,
@@ -443,6 +444,53 @@ class CliHealthAndBootstrapCommandTests(unittest.TestCase):
             cli.handle_bootstrap_plan_command(Namespace(json=True))
 
         self.assertEqual(json.loads(buf.getvalue()), expected)
+
+
+class CliQueryHistoryCommandTests(unittest.TestCase):
+    def test_handle_query_history_command_passes_since_hours_to_kernel(self):
+        cli = _load_cli_module()
+
+        class ExpectedKernel:
+            def query_history_snapshot(self, limit=10, status="all", since_hours=None):
+                assert limit == 5
+                assert status == "error"
+                assert since_hours == 24
+                return {
+                    "log_file": "data/query_history.jsonl",
+                    "requested_limit": limit,
+                    "status_filter": status,
+                    "since_hours": since_hours,
+                    "entries_returned": 1,
+                    "entries_considered": 1,
+                    "success_count": 0,
+                    "error_count": 1,
+                    "corrupt_count": 0,
+                    "average_duration_ms": 123.0,
+                    "max_duration_ms": 123,
+                    "latest_status": "error",
+                    "latest_question": "recent failure",
+                    "latest_error": "timeout",
+                    "entries": [
+                        {
+                            "status": "error",
+                            "duration_ms": 123,
+                            "question": "recent failure",
+                            "timestamp": 1_800_000_000,
+                            "error": "timeout",
+                        }
+                    ],
+                }
+
+        cli.CiteWeaveKernel = ExpectedKernel
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.handle_query_history_command(Namespace(limit=5, status="error", since_hours=24, json=False))
+
+        output = buf.getvalue()
+        self.assertIn("Time window: last 24 hours", output)
+        self.assertIn("recent failure", output)
+        self.assertIn("timeout", output)
 
 
 class RepoHygieneTests(unittest.TestCase):

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -45,10 +45,11 @@ def _load_cli_module():
                 "addon_config_issues": [],
             }
 
-        def query_history_snapshot(self, limit=10):
+        def query_history_snapshot(self, limit=10, status="all"):
             return {
                 "log_file": "data/query_history.jsonl",
                 "requested_limit": limit,
+                "status_filter": status,
                 "entries_returned": 0,
                 "entries_considered": 0,
                 "success_count": 0,
@@ -58,6 +59,7 @@ def _load_cli_module():
                 "max_duration_ms": None,
                 "latest_status": None,
                 "latest_question": None,
+                "latest_error": None,
                 "entries": [],
             }
 
@@ -261,31 +263,34 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
         expected = {
             "log_file": "data/query_history.jsonl",
             "requested_limit": 5,
+            "status_filter": "error",
             "entries_returned": 2,
             "entries_considered": 2,
-            "success_count": 1,
-            "error_count": 1,
+            "success_count": 0,
+            "error_count": 2,
             "corrupt_count": 0,
-            "average_duration_ms": 175.0,
+            "average_duration_ms": 225.0,
             "max_duration_ms": 250,
             "latest_status": "error",
             "latest_question": "Why did retrieval fail?",
+            "latest_error": "retrieval unavailable",
             "entries": [
-                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250},
-                {"status": "success", "question": "Summarize Porter", "duration_ms": 100},
+                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250, "error": "retrieval unavailable"},
+                {"status": "error", "question": "Why did ranking fail?", "duration_ms": 200, "error": "timeout"},
             ],
         }
 
         class ExpectedKernel:
-            def query_history_snapshot(self, limit=10):
+            def query_history_snapshot(self, limit=10, status="all"):
                 assert limit == 5
+                assert status == "error"
                 return expected
 
         cli.CiteWeaveKernel = ExpectedKernel
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            cli.handle_query_history_command(Namespace(limit=5, json=True))
+            cli.handle_query_history_command(Namespace(limit=5, status="error", json=True))
 
         self.assertEqual(json.loads(buf.getvalue()), expected)
 
@@ -294,6 +299,7 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
         expected = {
             "log_file": "data/query_history.jsonl",
             "requested_limit": 2,
+            "status_filter": "all",
             "entries_returned": 2,
             "entries_considered": 2,
             "success_count": 1,
@@ -303,29 +309,33 @@ class CliQueryHistoryCommandTests(unittest.TestCase):
             "max_duration_ms": 250,
             "latest_status": "error",
             "latest_question": "Why did retrieval fail?",
+            "latest_error": "retrieval unavailable",
             "entries": [
-                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250},
+                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250, "error": "retrieval unavailable"},
                 {"status": "success", "question": "Summarize Porter", "duration_ms": 100},
             ],
         }
 
         class ExpectedKernel:
-            def query_history_snapshot(self, limit=10):
+            def query_history_snapshot(self, limit=10, status="all"):
                 assert limit == 2
+                assert status == "all"
                 return expected
 
         cli.CiteWeaveKernel = ExpectedKernel
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            cli.handle_query_history_command(Namespace(limit=2, json=False))
+            cli.handle_query_history_command(Namespace(limit=2, status="all", json=False))
 
         output = buf.getvalue()
+        self.assertIn("Status filter: all", output)
         self.assertIn("Successful queries: 1", output)
         self.assertIn("Failed queries: 1", output)
         self.assertIn("Average duration: 175.0 ms", output)
         self.assertIn("Slowest query: 250 ms", output)
-        self.assertIn("Latest query: error — Why did retrieval fail?", output)
+        self.assertIn("Latest query: error - Why did retrieval fail?", output)
+        self.assertIn("Latest error: retrieval unavailable", output)
         self.assertIn("[error] (250 ms) Why did retrieval fail?", output)
         self.assertIn("[success] (100 ms) Summarize Porter", output)
 

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -45,6 +45,22 @@ def _load_cli_module():
                 "addon_config_issues": [],
             }
 
+        def query_history_snapshot(self, limit=10):
+            return {
+                "log_file": "data/query_history.jsonl",
+                "requested_limit": limit,
+                "entries_returned": 0,
+                "entries_considered": 0,
+                "success_count": 0,
+                "error_count": 0,
+                "corrupt_count": 0,
+                "average_duration_ms": None,
+                "max_duration_ms": None,
+                "latest_status": None,
+                "latest_question": None,
+                "entries": [],
+            }
+
     _stub_module("prompt_toolkit", prompt=lambda *args, **kwargs: "")
     _stub_module("src", __path__=[])
     _stub_module("src.processing", __path__=[])
@@ -237,6 +253,81 @@ class CliProgressCommandTests(unittest.TestCase):
         self.assertIn("Tip: run batch-upload --resume", output)
         self.assertIn("Completed Files", output)
         self.assertIn("ok.pdf", output)
+
+
+class CliQueryHistoryCommandTests(unittest.TestCase):
+    def test_handle_query_history_command_supports_json_output(self):
+        cli = _load_cli_module()
+        expected = {
+            "log_file": "data/query_history.jsonl",
+            "requested_limit": 5,
+            "entries_returned": 2,
+            "entries_considered": 2,
+            "success_count": 1,
+            "error_count": 1,
+            "corrupt_count": 0,
+            "average_duration_ms": 175.0,
+            "max_duration_ms": 250,
+            "latest_status": "error",
+            "latest_question": "Why did retrieval fail?",
+            "entries": [
+                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250},
+                {"status": "success", "question": "Summarize Porter", "duration_ms": 100},
+            ],
+        }
+
+        class ExpectedKernel:
+            def query_history_snapshot(self, limit=10):
+                assert limit == 5
+                return expected
+
+        cli.CiteWeaveKernel = ExpectedKernel
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.handle_query_history_command(Namespace(limit=5, json=True))
+
+        self.assertEqual(json.loads(buf.getvalue()), expected)
+
+    def test_handle_query_history_command_text_output_is_actionable(self):
+        cli = _load_cli_module()
+        expected = {
+            "log_file": "data/query_history.jsonl",
+            "requested_limit": 2,
+            "entries_returned": 2,
+            "entries_considered": 2,
+            "success_count": 1,
+            "error_count": 1,
+            "corrupt_count": 0,
+            "average_duration_ms": 175.0,
+            "max_duration_ms": 250,
+            "latest_status": "error",
+            "latest_question": "Why did retrieval fail?",
+            "entries": [
+                {"status": "error", "question": "Why did retrieval fail?", "duration_ms": 250},
+                {"status": "success", "question": "Summarize Porter", "duration_ms": 100},
+            ],
+        }
+
+        class ExpectedKernel:
+            def query_history_snapshot(self, limit=10):
+                assert limit == 2
+                return expected
+
+        cli.CiteWeaveKernel = ExpectedKernel
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.handle_query_history_command(Namespace(limit=2, json=False))
+
+        output = buf.getvalue()
+        self.assertIn("Successful queries: 1", output)
+        self.assertIn("Failed queries: 1", output)
+        self.assertIn("Average duration: 175.0 ms", output)
+        self.assertIn("Slowest query: 250 ms", output)
+        self.assertIn("Latest query: error — Why did retrieval fail?", output)
+        self.assertIn("[error] (250 ms) Why did retrieval fail?", output)
+        self.assertIn("[success] (100 ms) Summarize Porter", output)
 
 
 class CliHealthAndBootstrapCommandTests(unittest.TestCase):

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -105,6 +105,128 @@ class CliRoutesCommandTests(unittest.TestCase):
         self.assertEqual(json.loads(buf.getvalue()), expected)
 
 
+class CliProgressCommandTests(unittest.TestCase):
+    def test_handle_progress_command_supports_json_output(self):
+        cli = _load_cli_module()
+        expected = {
+            "directory": "/papers",
+            "cleared": False,
+            "total_pdf_files": 3,
+            "summary": {
+                "total_tracked": 2,
+                "completed": 1,
+                "failed": 1,
+                "success_rate": 50.0,
+                "completed_files": ["/papers/ok.pdf"],
+                "failed_files": {"/papers/bad.pdf": "parse error"},
+                "aggregate_stats": {
+                    "total_sentences": 10,
+                    "sentences_with_citations": 4,
+                    "total_citations": 7,
+                    "total_references": 8,
+                },
+                "last_completed": {
+                    "pdf_path": "/papers/ok.pdf",
+                    "paper_id": "paper-1",
+                    "processed_at": 123,
+                    "stats": {"total_sentences": 10},
+                },
+                "failure_reasons": [{"error": "parse error", "count": 1}],
+            },
+            "pending_count": 2,
+            "pending_files": ["/papers/bad.pdf", "/papers/pending.pdf"],
+            "not_started_count": 1,
+            "not_started_files": ["/papers/pending.pdf"],
+            "retryable_failed_count": 1,
+            "retryable_failed_files": ["/papers/bad.pdf"],
+            "completed_count": 1,
+            "completed_files": ["/papers/ok.pdf"],
+            "failed_count": 1,
+            "failed_files": {"/papers/bad.pdf": "parse error"},
+        }
+
+        class ExpectedKernel:
+            def progress_summary(self, directory, clear=False):
+                assert directory == "/papers"
+                assert clear is False
+                return expected
+
+        cli.CiteWeaveKernel = ExpectedKernel
+        original_isdir = cli.os.path.isdir
+        cli.os.path.isdir = lambda path: path == "/papers"
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cli.handle_progress_command(Namespace(directory="/papers", clear=False, json=True, show_completed=False))
+        finally:
+            cli.os.path.isdir = original_isdir
+
+        self.assertEqual(json.loads(buf.getvalue()), expected)
+
+    def test_handle_progress_command_text_output_is_actionable(self):
+        cli = _load_cli_module()
+        progress = {
+            "directory": "/papers",
+            "cleared": False,
+            "total_pdf_files": 3,
+            "summary": {
+                "total_tracked": 2,
+                "completed": 1,
+                "failed": 1,
+                "success_rate": 50.0,
+                "completed_files": ["/papers/ok.pdf"],
+                "failed_files": {"/papers/bad.pdf": "parse error"},
+                "aggregate_stats": {
+                    "total_sentences": 10,
+                    "sentences_with_citations": 4,
+                    "total_citations": 7,
+                    "total_references": 8,
+                },
+                "last_completed": {
+                    "pdf_path": "/papers/ok.pdf",
+                    "paper_id": "paper-1",
+                    "processed_at": 123,
+                    "stats": {"total_sentences": 10},
+                },
+                "failure_reasons": [{"error": "parse error", "count": 1}],
+            },
+            "pending_count": 2,
+            "pending_files": ["/papers/bad.pdf", "/papers/pending.pdf"],
+            "not_started_count": 1,
+            "not_started_files": ["/papers/pending.pdf"],
+            "retryable_failed_count": 1,
+            "retryable_failed_files": ["/papers/bad.pdf"],
+            "completed_count": 1,
+            "completed_files": ["/papers/ok.pdf"],
+            "failed_count": 1,
+            "failed_files": {"/papers/bad.pdf": "parse error"},
+        }
+
+        class ExpectedKernel:
+            def progress_summary(self, directory, clear=False):
+                return progress
+
+        cli.CiteWeaveKernel = ExpectedKernel
+        original_isdir = cli.os.path.isdir
+        cli.os.path.isdir = lambda path: True
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cli.handle_progress_command(Namespace(directory="/papers", clear=False, json=False, show_completed=True))
+        finally:
+            cli.os.path.isdir = original_isdir
+
+        output = buf.getvalue()
+        self.assertIn("Pending / resumable: 2", output)
+        self.assertIn("Not started yet: 1", output)
+        self.assertIn("Retryable failed files: 1", output)
+        self.assertIn("Total sentences processed: 10", output)
+        self.assertIn("1 × parse error", output)
+        self.assertIn("Tip: run batch-upload --resume", output)
+        self.assertIn("Completed Files", output)
+        self.assertIn("ok.pdf", output)
+
+
 class CliHealthAndBootstrapCommandTests(unittest.TestCase):
     def test_handle_health_command_supports_json_output(self):
         cli = _load_cli_module()
@@ -208,6 +330,13 @@ class CliHealthAndBootstrapCommandTests(unittest.TestCase):
             cli.handle_bootstrap_plan_command(Namespace(json=True))
 
         self.assertEqual(json.loads(buf.getvalue()), expected)
+
+
+class RepoHygieneTests(unittest.TestCase):
+    def test_gitignore_explicitly_ignores_test_files_runtime_artifacts(self):
+        gitignore = (CLI_PATH.parents[2] / ".gitignore").read_text(encoding="utf-8")
+        self.assertIn("test_files/*", gitignore)
+        self.assertIn("!test_files/README.md", gitignore)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -125,10 +125,13 @@ class CliProgressCommandTests(unittest.TestCase):
                     "total_citations": 7,
                     "total_references": 8,
                 },
+                "total_completed_duration_seconds": 5.0,
+                "average_completed_duration_seconds": 5.0,
                 "last_completed": {
                     "pdf_path": "/papers/ok.pdf",
                     "paper_id": "paper-1",
                     "processed_at": 123,
+                    "duration_seconds": 5.0,
                     "stats": {"total_sentences": 10},
                 },
                 "failure_reasons": [{"error": "parse error", "count": 1}],
@@ -143,6 +146,8 @@ class CliProgressCommandTests(unittest.TestCase):
             "completed_files": ["/papers/ok.pdf"],
             "failed_count": 1,
             "failed_files": {"/papers/bad.pdf": "parse error"},
+            "average_completed_duration_seconds": 5.0,
+            "estimated_remaining_seconds": 10.0,
         }
 
         class ExpectedKernel:
@@ -182,10 +187,13 @@ class CliProgressCommandTests(unittest.TestCase):
                     "total_citations": 7,
                     "total_references": 8,
                 },
+                "total_completed_duration_seconds": 5.0,
+                "average_completed_duration_seconds": 5.0,
                 "last_completed": {
                     "pdf_path": "/papers/ok.pdf",
                     "paper_id": "paper-1",
                     "processed_at": 123,
+                    "duration_seconds": 5.0,
                     "stats": {"total_sentences": 10},
                 },
                 "failure_reasons": [{"error": "parse error", "count": 1}],
@@ -200,6 +208,8 @@ class CliProgressCommandTests(unittest.TestCase):
             "completed_files": ["/papers/ok.pdf"],
             "failed_count": 1,
             "failed_files": {"/papers/bad.pdf": "parse error"},
+            "average_completed_duration_seconds": 5.0,
+            "estimated_remaining_seconds": 10.0,
         }
 
         class ExpectedKernel:
@@ -220,6 +230,8 @@ class CliProgressCommandTests(unittest.TestCase):
         self.assertIn("Pending / resumable: 2", output)
         self.assertIn("Not started yet: 1", output)
         self.assertIn("Retryable failed files: 1", output)
+        self.assertIn("Observed average time per completed file: 5.0s", output)
+        self.assertIn("Estimated remaining wall time: 10.0s", output)
         self.assertIn("Total sentences processed: 10", output)
         self.assertIn("1 × parse error", output)
         self.assertIn("Tip: run batch-upload --resume", output)

--- a/tests/test_cli_routes_command.py
+++ b/tests/test_cli_routes_command.py
@@ -105,5 +105,60 @@ class CliRoutesCommandTests(unittest.TestCase):
         self.assertEqual(json.loads(buf.getvalue()), expected)
 
 
+class CliHealthAndBootstrapCommandTests(unittest.TestCase):
+    def test_handle_health_command_supports_json_output(self):
+        cli = _load_cli_module()
+        expected = {
+            "project_root": "/repo",
+            "env": {
+                "llm_provider": "openclaw",
+                "llm_model": "gpt-test",
+                "gateway_base": "http://localhost:18789/v1",
+            },
+            "files": {".env": True, "docker_compose": False},
+            "services": {
+                "qdrant": {"ok": True, "status": 200, "url": "http://localhost:6333/collections"},
+                "openclaw_gateway": {"ok": False, "status": 503, "url": "http://localhost:18789/v1/models", "error": "unavailable"},
+            },
+        }
+
+        class ExpectedKernel:
+            def health_snapshot(self):
+                return expected
+
+        cli.CiteWeaveKernel = ExpectedKernel
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.handle_health_command(Namespace(json=True))
+
+        self.assertEqual(json.loads(buf.getvalue()), expected)
+
+    def test_handle_bootstrap_plan_command_supports_json_output(self):
+        cli = _load_cli_module()
+        expected = {
+            "local_cli": {
+                "script": "bash scripts/bootstrap_local.sh",
+                "next_steps": [".venv/bin/python -m src.core.cli upload path/to/paper.pdf"],
+            },
+            "openclaw": {
+                "script": "bash scripts/bootstrap_openclaw.sh",
+                "next_steps": ["openclaw gateway status"],
+            },
+        }
+
+        class ExpectedKernel:
+            def bootstrap_plan(self):
+                return expected
+
+        cli.CiteWeaveKernel = ExpectedKernel
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.handle_bootstrap_plan_command(Namespace(json=True))
+
+        self.assertEqual(json.loads(buf.getvalue()), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_openclaw_facade.py
+++ b/tests/test_openclaw_facade.py
@@ -21,8 +21,8 @@ class FakeKernel:
     def diagnose_document(self, pdf_path):
         return {"ok": True, "pdf_path": pdf_path}
 
-    def query(self, question, confirmation="continue"):
-        return f"answer:{question}:{confirmation}"
+    def query(self, question, confirmation="continue", source="kernel.query"):
+        return f"answer:{question}:{confirmation}:{source}"
 
     def routes_snapshot(self):
         return {"default_route": "vector_search"}
@@ -48,7 +48,7 @@ class OpenClawFacadeTests(unittest.TestCase):
         mod = load_facade_module()
         facade = mod.OpenClawCiteWeaveFacade(kernel=FakeKernel())
         query_result = facade.query("hello", confirmation="continue")
-        self.assertEqual(query_result["answer"], "answer:hello:continue")
+        self.assertEqual(query_result["answer"], "answer:hello:continue:openclaw.facade.query")
         chat_result = facade.chat_turn("hi")
         self.assertEqual(chat_result["text"], "chat:hi")
 

--- a/tests/test_openclaw_facade.py
+++ b/tests/test_openclaw_facade.py
@@ -1,0 +1,63 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "src" / "adapters" / "openclaw_facade.py"
+
+
+def load_facade_module():
+    spec = importlib.util.spec_from_file_location("openclaw_facade_test_module", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeKernel:
+    def upload_document(self, pdf_path, save_results=True):
+        return {"paper_id": "paper-1", "processing_stats": {"total_sentences": 10}, "sentences_with_citations": []}
+
+    def diagnose_document(self, pdf_path):
+        return {"ok": True, "pdf_path": pdf_path}
+
+    def query(self, question, confirmation="continue"):
+        return f"answer:{question}:{confirmation}"
+
+    def routes_snapshot(self):
+        return {"default_route": "vector_search"}
+
+    def progress_summary(self, directory, clear=False):
+        return {"directory": directory, "cleared": clear}
+
+    def chat_turn(self, user_input, history=None, menu_choice=None, collected_data=None):
+        return {"text": f"chat:{user_input}", "needs_user_choice": False, "collected_data": collected_data or {}}
+
+    def batch_upload(self, directory, resume=True, force_restart=False, clear_progress=False):
+        return {"directory": directory, "processed_count": 3, "failed_count": 0}
+
+    def health_snapshot(self):
+        return {"services": {"openclaw_gateway": {"ok": True}}}
+
+    def bootstrap_plan(self):
+        return {"local_cli": {"script": "bash scripts/bootstrap_local.sh"}}
+
+
+class OpenClawFacadeTests(unittest.TestCase):
+    def test_facade_delegates_query_and_chat(self):
+        mod = load_facade_module()
+        facade = mod.OpenClawCiteWeaveFacade(kernel=FakeKernel())
+        query_result = facade.query("hello", confirmation="continue")
+        self.assertEqual(query_result["answer"], "answer:hello:continue")
+        chat_result = facade.chat_turn("hi")
+        self.assertEqual(chat_result["text"], "chat:hi")
+
+    def test_facade_exposes_health_and_bootstrap(self):
+        mod = load_facade_module()
+        facade = mod.OpenClawCiteWeaveFacade(kernel=FakeKernel())
+        self.assertTrue(facade.health()["services"]["openclaw_gateway"]["ok"])
+        self.assertEqual(facade.bootstrap_plan()["local_cli"]["script"], "bash scripts/bootstrap_local.sh")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_history.py
+++ b/tests/test_query_history.py
@@ -45,6 +45,39 @@ def test_query_history_recorder_appends_jsonl_entries():
         ]
 
 
+def test_query_history_summary_reports_recent_metrics_and_corrupt_rows():
+    query_history = _load_module(QUERY_HISTORY_PATH, f"query_history_summary_{uuid.uuid4().hex}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "query_history.jsonl"
+        log_path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"question": "old success", "status": "success", "duration_ms": 100}),
+                    "{not-json}",
+                    json.dumps({"question": "latest error", "status": "error", "duration_ms": 250}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        recorder = query_history.QueryHistoryRecorder(log_file=str(log_path))
+        summary = recorder.summary(limit=3)
+
+        assert summary["entries_returned"] == 3
+        assert summary["entries_considered"] == 2
+        assert summary["success_count"] == 1
+        assert summary["error_count"] == 1
+        assert summary["corrupt_count"] == 1
+        assert summary["average_duration_ms"] == 175.0
+        assert summary["max_duration_ms"] == 250
+        assert summary["latest_status"] == "error"
+        assert summary["latest_question"] == "latest error"
+        assert summary["entries"][0]["question"] == "latest error"
+        assert summary["entries"][1]["status"] == "corrupt"
+
+
 def test_kernel_query_records_success_metrics_to_history_file():
     query_history = _load_module(QUERY_HISTORY_PATH, f"src.kernel.query_history_{uuid.uuid4().hex}")
 
@@ -65,6 +98,7 @@ def test_kernel_query_records_success_metrics_to_history_file():
     _stub_module("src.agents.multi_agent_research_system", LangGraphResearchSystem=DummyResearchSystem)
     _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
     _stub_module("src.kernel", __path__=[])
+    _stub_module("src.kernel.batch_tracker", BatchUploadTracker=object)
     sys.modules["src.kernel.query_history"] = query_history
 
     service = _load_module(SERVICE_PATH, f"src.kernel.service_{uuid.uuid4().hex}")
@@ -110,6 +144,7 @@ def test_kernel_query_records_failures_before_reraising():
     _stub_module("src.agents.multi_agent_research_system", LangGraphResearchSystem=DummyResearchSystem)
     _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
     _stub_module("src.kernel", __path__=[])
+    _stub_module("src.kernel.batch_tracker", BatchUploadTracker=object)
     sys.modules["src.kernel.query_history"] = query_history
 
     service = _load_module(SERVICE_PATH, f"src.kernel.service_failure_{uuid.uuid4().hex}")

--- a/tests/test_query_history.py
+++ b/tests/test_query_history.py
@@ -66,6 +66,7 @@ def test_query_history_summary_reports_recent_metrics_and_corrupt_rows():
         summary = recorder.summary(limit=3)
 
         assert summary["status_filter"] == "all"
+        assert summary["source_filter"] == "all"
         assert summary["entries_returned"] == 3
         assert summary["entries_considered"] == 2
         assert summary["success_count"] == 1
@@ -75,6 +76,7 @@ def test_query_history_summary_reports_recent_metrics_and_corrupt_rows():
         assert summary["max_duration_ms"] == 250
         assert summary["latest_status"] == "error"
         assert summary["latest_question"] == "latest error"
+        assert summary["latest_source"] is None
         assert summary["latest_error"] is None
         assert summary["entries"][0]["question"] == "latest error"
         assert summary["entries"][1]["status"] == "corrupt"
@@ -88,9 +90,9 @@ def test_query_history_summary_can_filter_to_errors_only():
         log_path.write_text(
             "\n".join(
                 [
-                    json.dumps({"question": "ok", "status": "success", "duration_ms": 100}),
-                    json.dumps({"question": "broken", "status": "error", "duration_ms": 250, "error": "timeout"}),
-                    json.dumps({"question": "still broken", "status": "error", "duration_ms": 300, "error": "rate limit"}),
+                    json.dumps({"question": "ok", "status": "success", "duration_ms": 100, "source": "cli.query"}),
+                    json.dumps({"question": "broken", "status": "error", "duration_ms": 250, "error": "timeout", "source": "cli.query"}),
+                    json.dumps({"question": "still broken", "status": "error", "duration_ms": 300, "error": "rate limit", "source": "openclaw.facade.query"}),
                 ]
             )
             + "\n",
@@ -107,11 +109,16 @@ def test_query_history_summary_can_filter_to_errors_only():
         assert summary["error_count"] == 2
         assert summary["latest_status"] == "error"
         assert summary["latest_question"] == "still broken"
+        assert summary["latest_source"] == "openclaw.facade.query"
         assert summary["latest_error"] == "rate limit"
+        assert summary["source_breakdown"] == [
+            {"source": "openclaw.facade.query", "count": 1},
+            {"source": "cli.query", "count": 1},
+        ]
         assert [entry["question"] for entry in summary["entries"]] == ["still broken", "broken"]
 
 
-def test_query_history_summary_can_filter_to_recent_time_window():
+def test_query_history_summary_can_filter_to_source_and_recent_time_window():
     query_history = _load_module(QUERY_HISTORY_PATH, f"query_history_recent_{uuid.uuid4().hex}")
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -120,9 +127,9 @@ def test_query_history_summary_can_filter_to_recent_time_window():
         log_path.write_text(
             "\n".join(
                 [
-                    json.dumps({"question": "stale", "status": "success", "duration_ms": 90, "timestamp": now - 5 * 3600}),
-                    json.dumps({"question": "recent ok", "status": "success", "duration_ms": 110, "timestamp": now - 1800}),
-                    json.dumps({"question": "recent error", "status": "error", "duration_ms": 220, "timestamp": now - 600, "error": "timeout"}),
+                    json.dumps({"question": "stale", "status": "success", "duration_ms": 90, "timestamp": now - 5 * 3600, "source": "cli.query"}),
+                    json.dumps({"question": "recent ok", "status": "success", "duration_ms": 110, "timestamp": now - 1800, "source": "cli.query"}),
+                    json.dumps({"question": "recent error", "status": "error", "duration_ms": 220, "timestamp": now - 600, "error": "timeout", "source": "openclaw.facade.query"}),
                 ]
             )
             + "\n",
@@ -130,14 +137,15 @@ def test_query_history_summary_can_filter_to_recent_time_window():
         )
 
         recorder = query_history.QueryHistoryRecorder(log_file=str(log_path))
-        summary = recorder.summary(limit=10, since_hours=2, now=now)
+        summary = recorder.summary(limit=10, source="cli.query", since_hours=2, now=now)
 
         assert summary["since_hours"] == 2
-        assert summary["entries_returned"] == 2
-        assert summary["entries_considered"] == 2
+        assert summary["source_filter"] == "cli.query"
+        assert summary["entries_returned"] == 1
+        assert summary["entries_considered"] == 1
         assert summary["success_count"] == 1
-        assert summary["error_count"] == 1
-        assert [entry["question"] for entry in summary["entries"]] == ["recent error", "recent ok"]
+        assert summary["error_count"] == 0
+        assert [entry["question"] for entry in summary["entries"]] == ["recent ok"]
 
 
 def test_kernel_query_records_success_metrics_to_history_file():
@@ -170,7 +178,7 @@ def test_kernel_query_records_success_metrics_to_history_file():
         os.environ["CITEWEAVE_QUERY_HISTORY_FILE"] = str(log_path)
         try:
             kernel = service.CiteWeaveKernel()
-            response = kernel.query("Summarize Porter's theory")
+            response = kernel.query("Summarize Porter's theory", source="cli.query")
         finally:
             os.environ.pop("CITEWEAVE_QUERY_HISTORY_FILE", None)
 
@@ -181,6 +189,7 @@ def test_kernel_query_records_success_metrics_to_history_file():
         assert entry["question"] == "Summarize Porter's theory"
         assert entry["confirmation"] == "continue"
         assert entry["status"] == "success"
+        assert entry["source"] == "cli.query"
         assert entry["response_chars"] == len("Competitive advantage summary")
         assert entry["response_preview"] == "Competitive advantage summary"
         assert entry["satisfaction"] is None
@@ -217,7 +226,7 @@ def test_kernel_query_records_failures_before_reraising():
         try:
             kernel = service.CiteWeaveKernel()
             try:
-                kernel.query("Why is the model down?")
+                kernel.query("Why is the model down?", source="openclaw.facade.query")
                 assert False, "expected RuntimeError"
             except RuntimeError as exc:
                 assert str(exc) == "llm unavailable"
@@ -229,6 +238,7 @@ def test_kernel_query_records_failures_before_reraising():
         entry = rows[0]
         assert entry["question"] == "Why is the model down?"
         assert entry["status"] == "error"
+        assert entry["source"] == "openclaw.facade.query"
         assert entry["error"] == "llm unavailable"
         assert entry["response_chars"] == 0
         assert entry["response_preview"] == ""

--- a/tests/test_query_history.py
+++ b/tests/test_query_history.py
@@ -1,0 +1,138 @@
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import uuid
+from pathlib import Path
+
+
+QUERY_HISTORY_PATH = Path(__file__).resolve().parents[1] / "src" / "kernel" / "query_history.py"
+SERVICE_PATH = Path(__file__).resolve().parents[1] / "src" / "kernel" / "service.py"
+
+
+def _load_module(path: Path, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stub_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def test_query_history_recorder_appends_jsonl_entries():
+    query_history = _load_module(QUERY_HISTORY_PATH, f"query_history_{uuid.uuid4().hex}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "query_history.jsonl"
+        recorder = query_history.QueryHistoryRecorder(log_file=str(log_path))
+        recorder.record({"question": "What cites Porter (1980)?", "status": "success"})
+        recorder.record({"question": "Who refutes RBV?", "status": "error"})
+
+        rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+        assert rows == [
+            {"question": "What cites Porter (1980)?", "status": "success"},
+            {"question": "Who refutes RBV?", "status": "error"},
+        ]
+
+
+def test_kernel_query_records_success_metrics_to_history_file():
+    query_history = _load_module(QUERY_HISTORY_PATH, f"src.kernel.query_history_{uuid.uuid4().hex}")
+
+    class DummyDocumentProcessor:
+        pass
+
+    class DummyResearchSystem:
+        def research_question(self, question, confirmation):
+            assert question == "Summarize Porter's theory"
+            assert confirmation == "continue"
+            return "Competitive advantage summary"
+
+    _stub_module("src", __path__=[])
+    _stub_module("src.processing", __path__=[])
+    _stub_module("src.processing.pdf", __path__=[])
+    _stub_module("src.processing.pdf.document_processor", DocumentProcessor=DummyDocumentProcessor)
+    _stub_module("src.agents", __path__=[])
+    _stub_module("src.agents.multi_agent_research_system", LangGraphResearchSystem=DummyResearchSystem)
+    _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
+    _stub_module("src.kernel", __path__=[])
+    sys.modules["src.kernel.query_history"] = query_history
+
+    service = _load_module(SERVICE_PATH, f"src.kernel.service_{uuid.uuid4().hex}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "query_history.jsonl"
+        os.environ["CITEWEAVE_QUERY_HISTORY_FILE"] = str(log_path)
+        try:
+            kernel = service.CiteWeaveKernel()
+            response = kernel.query("Summarize Porter's theory")
+        finally:
+            os.environ.pop("CITEWEAVE_QUERY_HISTORY_FILE", None)
+
+        assert response == "Competitive advantage summary"
+        rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+        assert len(rows) == 1
+        entry = rows[0]
+        assert entry["question"] == "Summarize Porter's theory"
+        assert entry["confirmation"] == "continue"
+        assert entry["status"] == "success"
+        assert entry["response_chars"] == len("Competitive advantage summary")
+        assert entry["response_preview"] == "Competitive advantage summary"
+        assert entry["satisfaction"] is None
+        assert isinstance(entry["duration_ms"], int)
+        assert entry["duration_ms"] >= 0
+
+
+def test_kernel_query_records_failures_before_reraising():
+    query_history = _load_module(QUERY_HISTORY_PATH, f"src.kernel.query_history_{uuid.uuid4().hex}")
+
+    class DummyDocumentProcessor:
+        pass
+
+    class DummyResearchSystem:
+        def research_question(self, question, confirmation):
+            raise RuntimeError("llm unavailable")
+
+    _stub_module("src", __path__=[])
+    _stub_module("src.processing", __path__=[])
+    _stub_module("src.processing.pdf", __path__=[])
+    _stub_module("src.processing.pdf.document_processor", DocumentProcessor=DummyDocumentProcessor)
+    _stub_module("src.agents", __path__=[])
+    _stub_module("src.agents.multi_agent_research_system", LangGraphResearchSystem=DummyResearchSystem)
+    _stub_module("src.agents.routing", active_route_configuration=lambda: {"default_route": "vector_search"})
+    _stub_module("src.kernel", __path__=[])
+    sys.modules["src.kernel.query_history"] = query_history
+
+    service = _load_module(SERVICE_PATH, f"src.kernel.service_failure_{uuid.uuid4().hex}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "query_history.jsonl"
+        os.environ["CITEWEAVE_QUERY_HISTORY_FILE"] = str(log_path)
+        try:
+            kernel = service.CiteWeaveKernel()
+            try:
+                kernel.query("Why is the model down?")
+                assert False, "expected RuntimeError"
+            except RuntimeError as exc:
+                assert str(exc) == "llm unavailable"
+        finally:
+            os.environ.pop("CITEWEAVE_QUERY_HISTORY_FILE", None)
+
+        rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+        assert len(rows) == 1
+        entry = rows[0]
+        assert entry["question"] == "Why is the model down?"
+        assert entry["status"] == "error"
+        assert entry["error"] == "llm unavailable"
+        assert entry["response_chars"] == 0
+        assert entry["response_preview"] == ""
+        assert entry["satisfaction"] is None

--- a/tests/test_query_history.py
+++ b/tests/test_query_history.py
@@ -65,6 +65,7 @@ def test_query_history_summary_reports_recent_metrics_and_corrupt_rows():
         recorder = query_history.QueryHistoryRecorder(log_file=str(log_path))
         summary = recorder.summary(limit=3)
 
+        assert summary["status_filter"] == "all"
         assert summary["entries_returned"] == 3
         assert summary["entries_considered"] == 2
         assert summary["success_count"] == 1
@@ -74,8 +75,40 @@ def test_query_history_summary_reports_recent_metrics_and_corrupt_rows():
         assert summary["max_duration_ms"] == 250
         assert summary["latest_status"] == "error"
         assert summary["latest_question"] == "latest error"
+        assert summary["latest_error"] is None
         assert summary["entries"][0]["question"] == "latest error"
         assert summary["entries"][1]["status"] == "corrupt"
+
+
+def test_query_history_summary_can_filter_to_errors_only():
+    query_history = _load_module(QUERY_HISTORY_PATH, f"query_history_filtered_{uuid.uuid4().hex}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "query_history.jsonl"
+        log_path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"question": "ok", "status": "success", "duration_ms": 100}),
+                    json.dumps({"question": "broken", "status": "error", "duration_ms": 250, "error": "timeout"}),
+                    json.dumps({"question": "still broken", "status": "error", "duration_ms": 300, "error": "rate limit"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        recorder = query_history.QueryHistoryRecorder(log_file=str(log_path))
+        summary = recorder.summary(limit=2, status="error")
+
+        assert summary["status_filter"] == "error"
+        assert summary["entries_returned"] == 2
+        assert summary["entries_considered"] == 2
+        assert summary["success_count"] == 0
+        assert summary["error_count"] == 2
+        assert summary["latest_status"] == "error"
+        assert summary["latest_question"] == "still broken"
+        assert summary["latest_error"] == "rate limit"
+        assert [entry["question"] for entry in summary["entries"]] == ["still broken", "broken"]
 
 
 def test_kernel_query_records_success_metrics_to_history_file():

--- a/tests/test_query_history.py
+++ b/tests/test_query_history.py
@@ -111,6 +111,35 @@ def test_query_history_summary_can_filter_to_errors_only():
         assert [entry["question"] for entry in summary["entries"]] == ["still broken", "broken"]
 
 
+def test_query_history_summary_can_filter_to_recent_time_window():
+    query_history = _load_module(QUERY_HISTORY_PATH, f"query_history_recent_{uuid.uuid4().hex}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_path = Path(tmpdir) / "query_history.jsonl"
+        now = 1_800_000_000
+        log_path.write_text(
+            "\n".join(
+                [
+                    json.dumps({"question": "stale", "status": "success", "duration_ms": 90, "timestamp": now - 5 * 3600}),
+                    json.dumps({"question": "recent ok", "status": "success", "duration_ms": 110, "timestamp": now - 1800}),
+                    json.dumps({"question": "recent error", "status": "error", "duration_ms": 220, "timestamp": now - 600, "error": "timeout"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        recorder = query_history.QueryHistoryRecorder(log_file=str(log_path))
+        summary = recorder.summary(limit=10, since_hours=2, now=now)
+
+        assert summary["since_hours"] == 2
+        assert summary["entries_returned"] == 2
+        assert summary["entries_considered"] == 2
+        assert summary["success_count"] == 1
+        assert summary["error_count"] == 1
+        assert [entry["question"] for entry in summary["entries"]] == ["recent error", "recent ok"]
+
+
 def test_kernel_query_records_success_metrics_to_history_file():
     query_history = _load_module(QUERY_HISTORY_PATH, f"src.kernel.query_history_{uuid.uuid4().hex}")
 


### PR DESCRIPTION
## Summary
- add aggregate sentence/citation/reference stats to batch progress summaries
- expose the most recent completed file and grouped failure reasons
- preserve real tracker stats when `batch-upload --sequential` is used
- extend tracker tests to cover the richer progress payload and sequential regression
- add CLI `health` and `bootstrap-plan` commands that expose existing kernel diagnostics in human-readable and JSON forms
- add CLI-level progress command coverage so the actionable summary/diagnostics path is locked in by tests
- add a lightweight kernel query-history recorder that logs question, latency, status, and a response preview to local JSONL telemetry
- add a first-class `query-history` CLI command so recent query latency/error trends can be inspected without reading raw JSONL by hand
- add repo-hygiene coverage to prevent regressions on the explicit `test_files/*` ignore rule
- add per-file duration tracking plus average/estimated remaining runtime in batch progress output so long-running ingests are easier to monitor
